### PR TITLE
Fix UpdateContext 422 by using valid default types

### DIFF
--- a/walkers/context_walkers.jac
+++ b/walkers/context_walkers.jac
@@ -38,10 +38,10 @@ walker:pub GetContext {
 
 
 walker:pub UpdateContext {
-    has currentUser: dict = None,
-        currentGraph: dict = None,
-        currentSession: dict = None,
-        currentScreen: str = None;
+    has currentUser: dict = {},
+        currentGraph: dict = {},
+        currentSession: dict = {},
+        currentScreen: str = "";
 
     can run with Root entry {
         ctx = None;
@@ -55,10 +55,10 @@ walker:pub UpdateContext {
             ctx = (root ++> AppContext())[0];
         }
 
-        if self.currentUser is not None { ctx.currentUser = self.currentUser; }
-        if self.currentGraph is not None { ctx.currentGraph = self.currentGraph; }
-        if self.currentSession is not None { ctx.currentSession = self.currentSession; }
-        if self.currentScreen is not None { ctx.currentScreen = self.currentScreen; }
+        if self.currentUser { ctx.currentUser = self.currentUser; }
+        if self.currentGraph { ctx.currentGraph = self.currentGraph; }
+        if self.currentSession { ctx.currentSession = self.currentSession; }
+        if self.currentScreen { ctx.currentScreen = self.currentScreen; }
 
         report ctx;
     }


### PR DESCRIPTION
Walker params declared as `dict = None` caused Pydantic to treat them as required fields since None isn't a valid dict. Changed defaults to `{}` and `""` so omitted fields no longer trigger 422 errors.