### PR TITLE
feat reserve dragged node positions across graph relayout

### DIFF
--- a/components/ArgumentGraphView.cl.jac
+++ b/components/ArgumentGraphView.cl.jac
@@ -46,14 +46,46 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         viewY: float           = 40.0,
         scale: float           = 1.0;
 
+    def estimateNodeBox(nodeItem: dict) -> dict {
+        node_content = nodeItem["content"] if "content" in nodeItem else "";
+        max_chars = 26;
+        line_count = 1;
+        if len(node_content) > max_chars {
+            words = node_content.split(" ");
+            cur = "";
+            lines: list = [];
+            for w in words {
+                test = (cur + " " + w).trim() if cur else w;
+                if len(test) <= max_chars {
+                    cur = test;
+                } else {
+                    if cur { lines.append(cur); }
+                    cur = w;
+                }
+            }
+            if cur { lines.append(cur); }
+            line_count = min(3, len(lines)) if len(lines) > 0 else 1;
+        }
+        return {"w": NODE_W * 1.0, "h": max(70.0, 32.0 + line_count * 17.0 + 12.0)};
+    }
+
+    def getNodeBox(nid: str) -> dict {
+        fi = 0;
+        while fi < len(nodes) {
+            if nodes[fi]["id"] == nid {
+                return estimateNodeBox(nodes[fi]);
+            }
+            fi = fi + 1;
+        }
+        return {"w": NODE_W * 1.0, "h": NODE_H * 1.0};
+    }
+
     can with entry {
         n_count = len(nodes);
-        n_edges = len(edges);
         if n_count == 0 { return; }
 
-        # ── Build parallel arrays: ids[], xs[], ys[], vxs[], vys[] ──
-        # Using ONLY index-based while loops (no for-in on dicts)
-
+        # Real graph nodes determine the main layered layout.
+        # Suggested ghost nodes are positioned after layout as anchored callouts.
         ids: list = [];
         xs: list = [];
         ys: list = [];
@@ -62,30 +94,46 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         txs: list = [];
         tys: list = [];
         depths: list = [];
+        isGhostNode: list = [];
+        halfWs: list = [];
+        halfHs: list = [];
 
-        # Initialize from node positions
         ni = 0;
         while ni < n_count {
-            ids.append(nodes[ni]["id"]);
-            xs.append(nodes[ni]["position"]["x"] if "position" in nodes[ni] else 0.0);
-            ys.append(nodes[ni]["position"]["y"] if "position" in nodes[ni] else 0.0);
+            node_item = nodes[ni];
+            node_box = estimateNodeBox(node_item);
+            ghost_flag = node_item["isGhost"] if "isGhost" in node_item else False;
+            ids.append(node_item["id"]);
+            xs.append(node_item["position"]["x"] if "position" in node_item else 0.0);
+            ys.append(node_item["position"]["y"] if "position" in node_item else 0.0);
             vxs.append(0.0);
             vys.append(0.0);
             txs.append(0.0);
             tys.append(0.0);
             depths.append(-1);
+            isGhostNode.append(ghost_flag);
+            halfWs.append(node_box["w"] / 2.0);
+            halfHs.append(node_box["h"] / 2.0);
             ni = ni + 1;
         }
 
-        # Find index of root (THESIS or first)
         root_idx = 0;
         ri = 0;
         while ri < n_count {
-            if nodes[ri]["type"] == "THESIS" { root_idx = ri; break; }
+            if not isGhostNode[ri] and nodes[ri]["type"] == "THESIS" { root_idx = ri; break; }
             ri = ri + 1;
         }
+        if isGhostNode[root_idx] {
+            ri = 0;
+            while ri < n_count {
+                if not isGhostNode[ri] {
+                    root_idx = ri;
+                    break;
+                }
+                ri = ri + 1;
+            }
+        }
 
-        # BFS to compute depths using index arrays
         depths[root_idx] = 0;
         bfs_queue: list = [root_idx];
         bqi = 0;
@@ -93,17 +141,19 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             ci = bfs_queue[bqi];
             cur_id = ids[ci];
             cur_d = depths[ci];
-            # Scan edges for neighbors
             ei = 0;
-            while ei < n_edges {
+            while ei < len(edges) {
                 nb_id = "";
-                if edges[ei]["source"] == cur_id { nb_id = edges[ei]["target"]; }
-                elif edges[ei]["target"] == cur_id { nb_id = edges[ei]["source"]; }
+                edge_type = edges[ei]["type"] if "type" in edges[ei] else "";
+                is_ghost_edge = edges[ei]["isGhost"] if "isGhost" in edges[ei] else False;
+                if not is_ghost_edge and (edge_type == "SUPPORTS" or edge_type == "ADDRESSES") {
+                    if edges[ei]["source"] == cur_id { nb_id = edges[ei]["target"]; }
+                    elif edges[ei]["target"] == cur_id { nb_id = edges[ei]["source"]; }
+                }
                 if nb_id {
-                    # Find index of neighbor
                     nbi = 0;
                     while nbi < n_count {
-                        if ids[nbi] == nb_id and depths[nbi] == -1 {
+                        if ids[nbi] == nb_id and (not isGhostNode[nbi]) and depths[nbi] == -1 {
                             depths[nbi] = cur_d + 1;
                             bfs_queue.append(nbi);
                             break;
@@ -116,128 +166,120 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             bqi = bqi + 1;
         }
 
-        # Fix disconnected nodes (depth still -1)
         max_d = 0;
         mi = 0;
         while mi < n_count {
-            if depths[mi] > max_d { max_d = depths[mi]; }
+            if (not isGhostNode[mi]) and depths[mi] > max_d { max_d = depths[mi]; }
             mi = mi + 1;
         }
         mi = 0;
         while mi < n_count {
-            if depths[mi] == -1 { depths[mi] = max_d + 1; }
+            if (not isGhostNode[mi]) and depths[mi] == -1 { depths[mi] = max_d + 1; }
             mi = mi + 1;
         }
 
-        # Count nodes per depth layer and compute BFS target positions
-        # First pass: count per layer
         max_layer = 0;
         mi = 0;
         while mi < n_count {
-            if depths[mi] > max_layer { max_layer = depths[mi]; }
+            if (not isGhostNode[mi]) and depths[mi] > max_layer { max_layer = depths[mi]; }
             mi = mi + 1;
         }
 
-        # For each layer, count nodes and assign x positions
         layer = 0;
+        current_y = 0.0;
         while layer <= max_layer {
-            # Count nodes in this layer
             count = 0;
+            layer_max_h = 70.0;
             ci = 0;
             while ci < n_count {
-                if depths[ci] == layer { count = count + 1; }
+                if (not isGhostNode[ci]) and depths[ci] == layer {
+                    count = count + 1;
+                    if halfHs[ci] * 2.0 > layer_max_h { layer_max_h = halfHs[ci] * 2.0; }
+                }
                 ci = ci + 1;
             }
-            # Assign positions to nodes in this layer
             idx = 0;
             ci = 0;
             while ci < n_count {
-                if depths[ci] == layer {
-                    txs[ci] = (idx - (count - 1) / 2.0) * 250;
-                    tys[ci] = layer * 130.0;
-                    # Start nodes at their target positions
+                if (not isGhostNode[ci]) and depths[ci] == layer {
+                    txs[ci] = (idx - (count - 1) / 2.0) * 280.0;
+                    tys[ci] = current_y;
                     xs[ci] = txs[ci];
                     ys[ci] = tys[ci];
                     idx = idx + 1;
                 }
                 ci = ci + 1;
             }
+            current_y = current_y + layer_max_h + 96.0;
             layer = layer + 1;
         }
 
-        # Precompute edge source/target indices
-        edge_si: list = [];
-        edge_ti: list = [];
+        force_si: list = [];
+        force_ti: list = [];
         ei = 0;
-        while ei < n_edges {
+        while ei < len(edges) {
             src = edges[ei]["source"];
             tgt = edges[ei]["target"];
-            si = -1;
-            ti = -1;
-            fi = 0;
-            while fi < n_count {
-                if ids[fi] == src { si = fi; }
-                if ids[fi] == tgt { ti = fi; }
-                fi = fi + 1;
+            edge_type = edges[ei]["type"] if "type" in edges[ei] else "";
+            is_ghost_edge = edges[ei]["isGhost"] if "isGhost" in edges[ei] else False;
+            if not is_ghost_edge and (edge_type == "SUPPORTS" or edge_type == "ADDRESSES") {
+                si = -1;
+                ti = -1;
+                fi = 0;
+                while fi < n_count {
+                    if ids[fi] == src and (not isGhostNode[fi]) { si = fi; }
+                    if ids[fi] == tgt and (not isGhostNode[fi]) { ti = fi; }
+                    fi = fi + 1;
+                }
+                if si >= 0 and ti >= 0 {
+                    force_si.append(si);
+                    force_ti.append(ti);
+                }
             }
-            edge_si.append(si);
-            edge_ti.append(ti);
             ei = ei + 1;
         }
 
-        # Compute degrees for link bias
         degs: list = [];
         di = 0;
         while di < n_count { degs.append(0); di = di + 1; }
         ei = 0;
-        while ei < n_edges {
-            if edge_si[ei] >= 0 { degs[edge_si[ei]] = degs[edge_si[ei]] + 1; }
-            if edge_ti[ei] >= 0 { degs[edge_ti[ei]] = degs[edge_ti[ei]] + 1; }
+        while ei < len(force_si) {
+            degs[force_si[ei]] = degs[force_si[ei]] + 1;
+            degs[force_ti[ei]] = degs[force_ti[ei]] + 1;
             ei = ei + 1;
         }
-
-        # ── Force simulation: exact d3-force parameters from mockup ──
-        # forceLink:     distance=140, strength=0.05
-        # forceManyBody: strength=-80, distanceMax=300
-        # forceCollide:  radius=112
-        # forceX:        strength=0.08
-        # forceY:        strength=0.3
-        # alphaDecay=0.12, velocityDecay=0.75 (internal=0.25), alpha=0.3, 150 ticks
 
         alpha = 0.3;
         tick = 0;
         while tick < 150 {
-            # Alpha decay
             alpha = alpha * 0.88;
 
-            # Link force
             ei = 0;
-            while ei < n_edges {
-                si = edge_si[ei];
-                ti = edge_ti[ei];
-                if si >= 0 and ti >= 0 {
-                    dx = xs[ti] + vxs[ti] - xs[si] - vxs[si];
-                    dy = ys[ti] + vys[ti] - ys[si] - vys[si];
-                    dist = (dx * dx + dy * dy) ** 0.5;
-                    if dist < 0.001 { dist = 0.001; }
-                    strength = (dist - 140.0) / dist * alpha * 0.05;
-                    fx = dx * strength;
-                    fy = dy * strength;
-                    total_deg = degs[si] + degs[ti];
-                    bias = degs[ti] / total_deg if total_deg > 0 else 0.5;
-                    vxs[ti] = vxs[ti] - fx * bias;
-                    vys[ti] = vys[ti] - fy * bias;
-                    vxs[si] = vxs[si] + fx * (1.0 - bias);
-                    vys[si] = vys[si] + fy * (1.0 - bias);
-                }
+            while ei < len(force_si) {
+                si = force_si[ei];
+                ti = force_ti[ei];
+                dx = xs[ti] + vxs[ti] - xs[si] - vxs[si];
+                dy = ys[ti] + vys[ti] - ys[si] - vys[si];
+                dist = (dx * dx + dy * dy) ** 0.5;
+                if dist < 0.001 { dist = 0.001; }
+                strength = (dist - 170.0) / dist * alpha * 0.05;
+                fx = dx * strength;
+                fy = dy * strength;
+                total_deg = degs[si] + degs[ti];
+                bias = degs[ti] / total_deg if total_deg > 0 else 0.5;
+                vxs[ti] = vxs[ti] - fx * bias;
+                vys[ti] = vys[ti] - fy * bias;
+                vxs[si] = vxs[si] + fx * (1.0 - bias);
+                vys[si] = vys[si] + fy * (1.0 - bias);
                 ei = ei + 1;
             }
 
-            # Many-body (charge) force
             ia = 0;
             while ia < n_count {
+                if isGhostNode[ia] { ia = ia + 1; continue; }
                 ib = ia + 1;
                 while ib < n_count {
+                    if isGhostNode[ib] { ib = ib + 1; continue; }
                     dx = xs[ib] - xs[ia];
                     dy = ys[ib] - ys[ia];
                     dist_sq = dx * dx + dy * dy;
@@ -256,65 +298,137 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                 ia = ia + 1;
             }
 
-            # Collision force (radius=112, pair min distance=224)
             ia = 0;
             while ia < n_count {
+                if isGhostNode[ia] { ia = ia + 1; continue; }
                 ib = ia + 1;
                 while ib < n_count {
+                    if isGhostNode[ib] { ib = ib + 1; continue; }
                     dx = xs[ib] - xs[ia];
                     dy = ys[ib] - ys[ia];
-                    dist = (dx * dx + dy * dy) ** 0.5;
-                    if dist < 224.0 and dist > 0.01 {
-                        overlap = (224.0 - dist) / dist * 0.5;
-                        vxs[ib] = vxs[ib] + dx * overlap;
-                        vys[ib] = vys[ib] + dy * overlap;
-                        vxs[ia] = vxs[ia] - dx * overlap;
-                        vys[ia] = vys[ia] - dy * overlap;
+                    overlap_x = (halfWs[ia] + halfWs[ib] + 28.0) - abs(dx);
+                    overlap_y = (halfHs[ia] + halfHs[ib] + 28.0) - abs(dy);
+                    if overlap_x > 0.0 and overlap_y > 0.0 {
+                        if overlap_x < overlap_y {
+                            push_x = overlap_x * 0.5;
+                            if dx >= 0.0 {
+                                vxs[ib] = vxs[ib] + push_x;
+                                vxs[ia] = vxs[ia] - push_x;
+                            } else {
+                                vxs[ib] = vxs[ib] - push_x;
+                                vxs[ia] = vxs[ia] + push_x;
+                            }
+                        } else {
+                            push_y = overlap_y * 0.5;
+                            if dy >= 0.0 {
+                                vys[ib] = vys[ib] + push_y;
+                                vys[ia] = vys[ia] - push_y;
+                            } else {
+                                vys[ib] = vys[ib] - push_y;
+                                vys[ia] = vys[ia] + push_y;
+                            }
+                        }
                     }
                     ib = ib + 1;
                 }
                 ia = ia + 1;
             }
 
-            # X/Y positioning forces
             pi = 0;
             while pi < n_count {
-                vxs[pi] = vxs[pi] + (txs[pi] - xs[pi]) * 0.08 * alpha;
-                vys[pi] = vys[pi] + (tys[pi] - ys[pi]) * 0.3 * alpha;
+                if not isGhostNode[pi] {
+                    vxs[pi] = vxs[pi] + (txs[pi] - xs[pi]) * 0.08 * alpha;
+                    vys[pi] = vys[pi] + (tys[pi] - ys[pi]) * 0.3 * alpha;
+                }
                 pi = pi + 1;
             }
 
-            # Apply velocity with decay (d3: vx *= 1-velocityDecay, then x += vx)
             pi = 0;
             while pi < n_count {
-                vxs[pi] = vxs[pi] * 0.25;
-                vys[pi] = vys[pi] * 0.25;
-                xs[pi] = xs[pi] + vxs[pi];
-                ys[pi] = ys[pi] + vys[pi];
+                if not isGhostNode[pi] {
+                    vxs[pi] = vxs[pi] * 0.25;
+                    vys[pi] = vys[pi] * 0.25;
+                    xs[pi] = xs[pi] + vxs[pi];
+                    ys[pi] = ys[pi] + vys[pi];
+                }
                 pi = pi + 1;
             }
 
             tick = tick + 1;
         }
 
-        # Normalize positions
         min_x = 99999.0;
         min_y = 99999.0;
         pi = 0;
         while pi < n_count {
-            if xs[pi] < min_x { min_x = xs[pi]; }
-            if ys[pi] < min_y { min_y = ys[pi]; }
+            if not isGhostNode[pi] {
+                if xs[pi] < min_x { min_x = xs[pi]; }
+                if ys[pi] < min_y { min_y = ys[pi]; }
+            }
             pi = pi + 1;
         }
 
         positions: dict = {};
         pi = 0;
         while pi < n_count {
-            positions[ids[pi]] = {
-                "x": xs[pi] - min_x + 200,
-                "y": ys[pi] - min_y + 100
-            };
+            if not isGhostNode[pi] {
+                positions[ids[pi]] = {
+                    "x": xs[pi] - min_x + 200,
+                    "y": ys[pi] - min_y + 100
+                };
+            }
             pi = pi + 1;
+        }
+
+        # Counterargument-style nodes and suggested ghost nodes render in a side lane
+        # instead of influencing the main structural layout.
+        contra_groups: dict = {};
+        ei = 0;
+        while ei < len(edges) {
+            edge_type = edges[ei]["type"] if "type" in edges[ei] else "";
+            if edge_type == "CONTRADICTS" {
+                src = edges[ei]["source"];
+                tgt = edges[ei]["target"];
+                if tgt in positions {
+                    if tgt not in contra_groups {
+                        contra_groups[tgt] = [];
+                    }
+                    contra_groups[tgt].append(src);
+                }
+            }
+            ei = ei + 1;
+        }
+
+        ti = 0;
+        while ti < len(nodes) {
+            tgt_id = nodes[ti]["id"];
+            if tgt_id in contra_groups and tgt_id in positions {
+                contra_ids = contra_groups[tgt_id];
+                cj = 0;
+                while cj < len(contra_ids) {
+                    src_id = contra_ids[cj];
+                    src_box = getNodeBox(src_id);
+                    tgt_box = getNodeBox(tgt_id);
+                    vertical_gap = max(110.0, (src_box["h"] + tgt_box["h"]) / 2.0 + 24.0);
+                    target_pos = positions[tgt_id];
+                    is_ghost_src = False;
+                    si = 0;
+                    while si < len(nodes) {
+                        if nodes[si]["id"] == src_id {
+                            is_ghost_src = nodes[si]["isGhost"] if "isGhost" in nodes[si] else False;
+                            break;
+                        }
+                        si = si + 1;
+                    }
+                    extra_x = 120.0 if is_ghost_src else 0.0;
+                    positions[src_id] = {
+                        "x": target_pos["x"] + 280.0 + extra_x,
+                        "y": target_pos["y"] + (cj - (len(contra_ids) - 1) / 2.0) * vertical_gap
+                    };
+                    cj = cj + 1;
+                }
+            }
+            ti = ti + 1;
         }
 
         nodePositions = positions;
@@ -460,14 +574,18 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         cur_e = edges[ei];
         s_pos = getPos(cur_e["source"]);
         t_pos = getPos(cur_e["target"]);
+        s_box = getNodeBox(cur_e["source"]);
+        t_box = getNodeBox(cur_e["target"]);
         sx = s_pos["x"]; sy = s_pos["y"];
         tx = t_pos["x"]; ty = t_pos["y"];
-        mid_y = (sy + 40 + ty - 40) / 2.0;
+        s_half_h = s_box["h"] / 2.0;
+        t_half_h = t_box["h"] / 2.0;
+        mid_y = (sy + s_half_h + ty - t_half_h) / 2.0;
         mx = (sx + tx) / 2.0;
         color  = edgeColor(cur_e["type"]);
         dash   = edgeDash(cur_e["type"]);
 
-        path_d = f"M {sx},{sy + 40} C {sx},{mid_y} {tx},{mid_y} {tx},{ty - 40}";
+        path_d = f"M {sx},{sy + s_half_h} C {sx},{mid_y} {tx},{mid_y} {tx},{ty - t_half_h}";
 
         e_type = cur_e["type"];
         mkr_id = "mk-sup";

--- a/components/ArgumentGraphView.cl.jac
+++ b/components/ArgumentGraphView.cl.jac
@@ -11,6 +11,8 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
     edges       = list(props.edges) if props.edges else [];
     onNodeClick = props.onNodeClick if props.onNodeClick else None;
     onGhostAccept = props.onGhostAccept if props.onGhostAccept else None;
+    savedNodePositions = props.layoutHints if props.layoutHints else {};
+    onNodePositionsChange = props.onNodePositionsChange if props.onNodePositionsChange else None;
     selectedNodeId = props.selectedNodeId if props.selectedNodeId else None;
     focusBranch = props.focusBranch if props.focusBranch else None;
 
@@ -97,15 +99,20 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         isGhostNode: list = [];
         halfWs: list = [];
         halfHs: list = [];
+        hasSavedHint: list = [];
+        seededXs: list = [];
+        seededYs: list = [];
 
         ni = 0;
         while ni < n_count {
             node_item = nodes[ni];
             node_box = estimateNodeBox(node_item);
             ghost_flag = node_item["isGhost"] if "isGhost" in node_item else False;
+            node_id = node_item["id"];
+            seeded_pos = savedNodePositions[node_id] if node_id in savedNodePositions else (node_item["position"] if "position" in node_item else {"x": 0.0, "y": 0.0});
             ids.append(node_item["id"]);
-            xs.append(node_item["position"]["x"] if "position" in node_item else 0.0);
-            ys.append(node_item["position"]["y"] if "position" in node_item else 0.0);
+            xs.append(float(seeded_pos["x"]));
+            ys.append(float(seeded_pos["y"]));
             vxs.append(0.0);
             vys.append(0.0);
             txs.append(0.0);
@@ -114,6 +121,9 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             isGhostNode.append(ghost_flag);
             halfWs.append(node_box["w"] / 2.0);
             halfHs.append(node_box["h"] / 2.0);
+            hasSavedHint.append(node_id in savedNodePositions);
+            seededXs.append(float(seeded_pos["x"]));
+            seededYs.append(float(seeded_pos["y"]));
             ni = ni + 1;
         }
 
@@ -202,9 +212,12 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             ci = 0;
             while ci < n_count {
                 if (not isGhostNode[ci]) and depths[ci] == layer {
-                    txs[ci] = (idx - (count - 1) / 2.0) * 280.0;
+                    default_x = (idx - (count - 1) / 2.0) * 280.0;
+                    txs[ci] = seededXs[ci] if hasSavedHint[ci] else default_x;
                     tys[ci] = current_y;
-                    xs[ci] = txs[ci];
+                    if not hasSavedHint[ci] {
+                        xs[ci] = txs[ci];
+                    }
                     ys[ci] = tys[ci];
                     idx = idx + 1;
                 }
@@ -421,10 +434,14 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                         si = si + 1;
                     }
                     extra_x = 120.0 if is_ghost_src else 0.0;
-                    positions[src_id] = {
-                        "x": target_pos["x"] + 280.0 + extra_x,
-                        "y": target_pos["y"] + (cj - (len(contra_ids) - 1) / 2.0) * vertical_gap
-                    };
+                    if src_id in savedNodePositions {
+                        positions[src_id] = savedNodePositions[src_id];
+                    } else {
+                        positions[src_id] = {
+                            "x": target_pos["x"] + 280.0 + extra_x,
+                            "y": target_pos["y"] + (cj - (len(contra_ids) - 1) / 2.0) * vertical_gap
+                        };
+                    }
                     cj = cj + 1;
                 }
             }
@@ -549,8 +566,12 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
     }
 
     def handleMouseUp(e: any) -> None {
+        if dragDidMove and onNodePositionsChange {
+            onNodePositionsChange(nodePositions);
+        }
         draggingNodeId = None;
         isPanning      = False;
+        dragDidMove    = False;
     }
 
     def handleNodeClickInternal(nodeItem: dict) -> None {

--- a/components/ArgumentGraphView.cl.jac
+++ b/components/ArgumentGraphView.cl.jac
@@ -13,6 +13,7 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
     onGhostAccept = props.onGhostAccept if props.onGhostAccept else None;
     savedNodePositions = props.layoutHints if props.layoutHints else {};
     onNodePositionsChange = props.onNodePositionsChange if props.onNodePositionsChange else None;
+    onLayoutResolved = props.onLayoutResolved if props.onLayoutResolved else None;
     selectedNodeId = props.selectedNodeId if props.selectedNodeId else None;
     focusBranch = props.focusBranch if props.focusBranch else None;
 
@@ -82,6 +83,222 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         return {"w": NODE_W * 1.0, "h": NODE_H * 1.0};
     }
 
+    def positionsChanged(next_positions: dict, prev_positions: dict) -> bool {
+        ni = 0;
+        while ni < len(nodes) {
+            node_id = nodes[ni]["id"];
+            is_ghost = nodes[ni]["isGhost"] if "isGhost" in nodes[ni] else False;
+            if is_ghost {
+                ni = ni + 1;
+                continue;
+            }
+            if node_id not in next_positions or node_id not in prev_positions {
+                return True;
+            }
+
+            next_pos = next_positions[node_id] if next_positions[node_id] else {"x": 0, "y": 0};
+            prev_pos = prev_positions[node_id] if prev_positions[node_id] else {"x": 0, "y": 0};
+            next_x = float(next_pos["x"]) if "x" in next_pos else 0.0;
+            next_y = float(next_pos["y"]) if "y" in next_pos else 0.0;
+            prev_x = float(prev_pos["x"]) if "x" in prev_pos else 0.0;
+            prev_y = float(prev_pos["y"]) if "y" in prev_pos else 0.0;
+            if abs(next_x - prev_x) > 0.5 or abs(next_y - prev_y) > 0.5 {
+                return True;
+            }
+            ni = ni + 1;
+        }
+        return False;
+    }
+
+    def clampAroundAnchor(value: float, anchor: float, limit: float) -> float {
+        delta = value - anchor;
+        if delta > limit { return anchor + limit; }
+        if delta < 0.0 - limit { return anchor - limit; }
+        return value;
+    }
+
+    def isNodeLocked(nodeId: str) -> bool {
+        ni = 0;
+        while ni < len(nodes) {
+            if nodes[ni]["id"] == nodeId {
+                return nodes[ni]["layoutLocked"] if "layoutLocked" in nodes[ni] else False;
+            }
+            ni = ni + 1;
+        }
+        return False;
+    }
+
+    def spreadDenseLayerNeighbors(raw_positions: dict, id_list: list, depth_list: list) -> dict {
+        result: dict = {};
+        if not raw_positions { return result; }
+
+        ri = 0;
+        while ri < len(id_list) {
+            node_id = id_list[ri];
+            if node_id in raw_positions {
+                pos = raw_positions[node_id] if raw_positions[node_id] else {"x": 0, "y": 0};
+                result[node_id] = {
+                    "x": float(pos["x"]) if "x" in pos else 0.0,
+                    "y": float(pos["y"]) if "y" in pos else 0.0
+                };
+            }
+            ri = ri + 1;
+        }
+
+        max_depth = 0;
+        di = 0;
+        while di < len(depth_list) {
+            if depth_list[di] > max_depth { max_depth = depth_list[di]; }
+            di = di + 1;
+        }
+
+        layer = 0;
+        while layer <= max_depth {
+            layer_ids: list = [];
+            li = 0;
+            while li < len(id_list) {
+                if depth_list[li] == layer and id_list[li] in result {
+                    layer_ids.append(id_list[li]);
+                }
+                li = li + 1;
+            }
+
+            li = 0;
+            while li < len(layer_ids) {
+                lj = li + 1;
+                while lj < len(layer_ids) {
+                    left_id = layer_ids[li];
+                    right_id = layer_ids[lj];
+                    left_x = result[left_id]["x"] if left_id in result else 0.0;
+                    right_x = result[right_id]["x"] if right_id in result else 0.0;
+                    if right_x < left_x {
+                        tmp_id = layer_ids[li];
+                        layer_ids[li] = layer_ids[lj];
+                        layer_ids[lj] = tmp_id;
+                    }
+                    lj = lj + 1;
+                }
+                li = li + 1;
+            }
+
+            pass_idx = 0;
+            while pass_idx < 3 {
+                li = 1;
+                while li < len(layer_ids) {
+                    prev_id = layer_ids[li - 1];
+                    curr_id = layer_ids[li];
+                    prev_box = getNodeBox(prev_id);
+                    curr_box = getNodeBox(curr_id);
+                    min_gap = (prev_box["w"] + curr_box["w"]) / 2.0 + 12.0;
+                    gap = result[curr_id]["x"] - result[prev_id]["x"];
+                    if gap < min_gap {
+                        needed = min_gap - gap;
+                        prev_locked = isNodeLocked(prev_id);
+                        curr_locked = isNodeLocked(curr_id);
+                        prev_share = 0.22 if prev_locked else 0.55;
+                        curr_share = 0.22 if curr_locked else 0.85;
+                        share_total = prev_share + curr_share;
+                        result[prev_id]["x"] = result[prev_id]["x"] - needed * (prev_share / share_total);
+                        result[curr_id]["x"] = result[curr_id]["x"] + needed * (curr_share / share_total);
+                    }
+                    li = li + 1;
+                }
+                pass_idx = pass_idx + 1;
+            }
+            layer = layer + 1;
+        }
+
+        return result;
+    }
+
+    def resolveOverlapPositions(raw_positions: dict) -> dict {
+        result: dict = {};
+        if not raw_positions { return result; }
+
+        ni = 0;
+        while ni < len(nodes) {
+            node_id = nodes[ni]["id"];
+            if node_id in raw_positions {
+                pos = raw_positions[node_id] if raw_positions[node_id] else {"x": 0, "y": 0};
+                result[node_id] = {
+                    "x": float(pos["x"]) if "x" in pos else 0.0,
+                    "y": float(pos["y"]) if "y" in pos else 0.0
+                };
+            }
+            ni = ni + 1;
+        }
+
+        pass_idx = 0;
+        while pass_idx < 8 {
+            any_moved = False;
+            ia = 0;
+            while ia < len(nodes) {
+                node_a = nodes[ia];
+                id_a = node_a["id"] if "id" in node_a else "";
+                if (not id_a) or id_a not in result {
+                    ia = ia + 1;
+                    continue;
+                }
+
+                pos_a = result[id_a];
+                box_a = getNodeBox(id_a);
+                locked_a = node_a["layoutLocked"] if "layoutLocked" in node_a else False;
+                mobility_a = 0.28 if locked_a else 1.0;
+
+                ib = ia + 1;
+                while ib < len(nodes) {
+                    node_b = nodes[ib];
+                    id_b = node_b["id"] if "id" in node_b else "";
+                    if (not id_b) or id_b not in result {
+                        ib = ib + 1;
+                        continue;
+                    }
+
+                    pos_b = result[id_b];
+                    box_b = getNodeBox(id_b);
+                    locked_b = node_b["layoutLocked"] if "layoutLocked" in node_b else False;
+                    mobility_b = 0.28 if locked_b else 1.0;
+
+                    dx = pos_b["x"] - pos_a["x"];
+                    dy = pos_b["y"] - pos_a["y"];
+                    min_x_gap = (box_a["w"] + box_b["w"]) / 2.0 + 10.0;
+                    min_y_gap = (box_a["h"] + box_b["h"]) / 2.0 + 8.0;
+                    overlap_x = min_x_gap - abs(dx);
+                    overlap_y = min_y_gap - abs(dy);
+
+                    if overlap_x > 0.0 and overlap_y > 0.0 {
+                        total_mobility = mobility_a + mobility_b;
+                        share_a = mobility_a / total_mobility if total_mobility > 0.0 else 0.5;
+                        share_b = mobility_b / total_mobility if total_mobility > 0.0 else 0.5;
+
+                        if overlap_x <= overlap_y {
+                            push_x = overlap_x + 2.0;
+                            dir_x = 1.0 if dx >= 0.0 else -1.0;
+                            pos_a["x"] = pos_a["x"] - dir_x * push_x * share_a;
+                            pos_b["x"] = pos_b["x"] + dir_x * push_x * share_b;
+                        } else {
+                            push_y = overlap_y + 2.0;
+                            dir_y = 1.0 if dy >= 0.0 else -1.0;
+                            pos_a["y"] = pos_a["y"] - dir_y * push_y * share_a;
+                            pos_b["y"] = pos_b["y"] + dir_y * push_y * share_b;
+                        }
+
+                        result[id_a] = pos_a;
+                        result[id_b] = pos_b;
+                        any_moved = True;
+                    }
+                    ib = ib + 1;
+                }
+                ia = ia + 1;
+            }
+
+            if not any_moved { break; }
+            pass_idx = pass_idx + 1;
+        }
+
+        return result;
+    }
+
     can with entry {
         n_count = len(nodes);
         if n_count == 0 { return; }
@@ -99,7 +316,8 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
         isGhostNode: list = [];
         halfWs: list = [];
         halfHs: list = [];
-        hasSavedHint: list = [];
+        hasSeededPosition: list = [];
+        isLockedNode: list = [];
         seededXs: list = [];
         seededYs: list = [];
 
@@ -109,7 +327,8 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             node_box = estimateNodeBox(node_item);
             ghost_flag = node_item["isGhost"] if "isGhost" in node_item else False;
             node_id = node_item["id"];
-            seeded_pos = savedNodePositions[node_id] if node_id in savedNodePositions else (node_item["position"] if "position" in node_item else {"x": 0.0, "y": 0.0});
+            node_has_position = "position" in node_item;
+            seeded_pos = savedNodePositions[node_id] if node_id in savedNodePositions else (node_item["position"] if node_has_position else {"x": 0.0, "y": 0.0});
             ids.append(node_item["id"]);
             xs.append(float(seeded_pos["x"]));
             ys.append(float(seeded_pos["y"]));
@@ -121,7 +340,8 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             isGhostNode.append(ghost_flag);
             halfWs.append(node_box["w"] / 2.0);
             halfHs.append(node_box["h"] / 2.0);
-            hasSavedHint.append(node_id in savedNodePositions);
+            hasSeededPosition.append((node_id in savedNodePositions) or node_has_position);
+            isLockedNode.append(node_item["layoutLocked"] if "layoutLocked" in node_item else False);
             seededXs.append(float(seeded_pos["x"]));
             seededYs.append(float(seeded_pos["y"]));
             ni = ni + 1;
@@ -212,18 +432,18 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             ci = 0;
             while ci < n_count {
                 if (not isGhostNode[ci]) and depths[ci] == layer {
-                    default_x = (idx - (count - 1) / 2.0) * 280.0;
-                    txs[ci] = seededXs[ci] if hasSavedHint[ci] else default_x;
-                    tys[ci] = current_y;
-                    if not hasSavedHint[ci] {
+                    default_x = (idx - (count - 1) / 2.0) * 248.0;
+                    txs[ci] = seededXs[ci] if hasSeededPosition[ci] else default_x;
+                    tys[ci] = seededYs[ci] if hasSeededPosition[ci] else current_y;
+                    if not hasSeededPosition[ci] {
                         xs[ci] = txs[ci];
+                        ys[ci] = tys[ci];
                     }
-                    ys[ci] = tys[ci];
                     idx = idx + 1;
                 }
                 ci = ci + 1;
             }
-            current_y = current_y + layer_max_h + 96.0;
+            current_y = current_y + layer_max_h + 82.0;
             layer = layer + 1;
         }
 
@@ -278,12 +498,17 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                 strength = (dist - 170.0) / dist * alpha * 0.05;
                 fx = dx * strength;
                 fy = dy * strength;
+                mobility_si = 0.28 if isLockedNode[si] else 1.0;
+                mobility_ti = 0.28 if isLockedNode[ti] else 1.0;
                 total_deg = degs[si] + degs[ti];
                 bias = degs[ti] / total_deg if total_deg > 0 else 0.5;
-                vxs[ti] = vxs[ti] - fx * bias;
-                vys[ti] = vys[ti] - fy * bias;
-                vxs[si] = vxs[si] + fx * (1.0 - bias);
-                vys[si] = vys[si] + fy * (1.0 - bias);
+                total_mobility = mobility_si + mobility_ti;
+                share_si = mobility_si / total_mobility if total_mobility > 0.0 else 0.5;
+                share_ti = mobility_ti / total_mobility if total_mobility > 0.0 else 0.5;
+                vxs[ti] = vxs[ti] - fx * bias * share_ti;
+                vys[ti] = vys[ti] - fy * bias * share_ti;
+                vxs[si] = vxs[si] + fx * (1.0 - bias) * share_si;
+                vys[si] = vys[si] + fy * (1.0 - bias) * share_si;
                 ei = ei + 1;
             }
 
@@ -301,10 +526,15 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                         w = -80.0 * alpha / dist;
                         ux = dx / dist;
                         uy = dy / dist;
-                        vxs[ia] = vxs[ia] + ux * w;
-                        vys[ia] = vys[ia] + uy * w;
-                        vxs[ib] = vxs[ib] - ux * w;
-                        vys[ib] = vys[ib] - uy * w;
+                        mobility_a = 0.28 if isLockedNode[ia] else 1.0;
+                        mobility_b = 0.28 if isLockedNode[ib] else 1.0;
+                        total_mobility = mobility_a + mobility_b;
+                        share_a = mobility_a / total_mobility if total_mobility > 0.0 else 0.5;
+                        share_b = mobility_b / total_mobility if total_mobility > 0.0 else 0.5;
+                        vxs[ia] = vxs[ia] + ux * w * share_a;
+                        vys[ia] = vys[ia] + uy * w * share_a;
+                        vxs[ib] = vxs[ib] - ux * w * share_b;
+                        vys[ib] = vys[ib] - uy * w * share_b;
                     }
                     ib = ib + 1;
                 }
@@ -319,26 +549,31 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                     if isGhostNode[ib] { ib = ib + 1; continue; }
                     dx = xs[ib] - xs[ia];
                     dy = ys[ib] - ys[ia];
-                    overlap_x = (halfWs[ia] + halfWs[ib] + 28.0) - abs(dx);
-                    overlap_y = (halfHs[ia] + halfHs[ib] + 28.0) - abs(dy);
+                    overlap_x = (halfWs[ia] + halfWs[ib] + 12.0) - abs(dx);
+                    overlap_y = (halfHs[ia] + halfHs[ib] + 12.0) - abs(dy);
                     if overlap_x > 0.0 and overlap_y > 0.0 {
+                        mobility_a = 0.28 if isLockedNode[ia] else 1.0;
+                        mobility_b = 0.28 if isLockedNode[ib] else 1.0;
+                        total_mobility = mobility_a + mobility_b;
+                        share_a = mobility_a / total_mobility if total_mobility > 0.0 else 0.5;
+                        share_b = mobility_b / total_mobility if total_mobility > 0.0 else 0.5;
                         if overlap_x < overlap_y {
                             push_x = overlap_x * 0.5;
                             if dx >= 0.0 {
-                                vxs[ib] = vxs[ib] + push_x;
-                                vxs[ia] = vxs[ia] - push_x;
+                                vxs[ib] = vxs[ib] + push_x * share_b;
+                                vxs[ia] = vxs[ia] - push_x * share_a;
                             } else {
-                                vxs[ib] = vxs[ib] - push_x;
-                                vxs[ia] = vxs[ia] + push_x;
+                                vxs[ib] = vxs[ib] - push_x * share_b;
+                                vxs[ia] = vxs[ia] + push_x * share_a;
                             }
                         } else {
                             push_y = overlap_y * 0.5;
                             if dy >= 0.0 {
-                                vys[ib] = vys[ib] + push_y;
-                                vys[ia] = vys[ia] - push_y;
+                                vys[ib] = vys[ib] + push_y * share_b;
+                                vys[ia] = vys[ia] - push_y * share_a;
                             } else {
-                                vys[ib] = vys[ib] - push_y;
-                                vys[ia] = vys[ia] + push_y;
+                                vys[ib] = vys[ib] - push_y * share_b;
+                                vys[ia] = vys[ia] + push_y * share_a;
                             }
                         }
                     }
@@ -350,8 +585,10 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             pi = 0;
             while pi < n_count {
                 if not isGhostNode[pi] {
-                    vxs[pi] = vxs[pi] + (txs[pi] - xs[pi]) * 0.08 * alpha;
-                    vys[pi] = vys[pi] + (tys[pi] - ys[pi]) * 0.3 * alpha;
+                    anchor_strength_x = 0.2 if isLockedNode[pi] else (0.12 if hasSeededPosition[pi] else 0.08);
+                    anchor_strength_y = 0.34 if isLockedNode[pi] else (0.22 if hasSeededPosition[pi] else 0.3);
+                    vxs[pi] = vxs[pi] + (txs[pi] - xs[pi]) * anchor_strength_x * alpha;
+                    vys[pi] = vys[pi] + (tys[pi] - ys[pi]) * anchor_strength_y * alpha;
                 }
                 pi = pi + 1;
             }
@@ -359,10 +596,19 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             pi = 0;
             while pi < n_count {
                 if not isGhostNode[pi] {
-                    vxs[pi] = vxs[pi] * 0.25;
-                    vys[pi] = vys[pi] * 0.25;
+                    drag = 0.42 if isLockedNode[pi] else (0.3 if hasSeededPosition[pi] else 0.25);
+                    vxs[pi] = vxs[pi] * drag;
+                    vys[pi] = vys[pi] * drag;
                     xs[pi] = xs[pi] + vxs[pi];
                     ys[pi] = ys[pi] + vys[pi];
+
+                    if isLockedNode[pi] {
+                        xs[pi] = clampAroundAnchor(xs[pi], txs[pi], 44.0);
+                        ys[pi] = clampAroundAnchor(ys[pi], tys[pi], 44.0);
+                    } elif hasSeededPosition[pi] {
+                        xs[pi] = clampAroundAnchor(xs[pi], txs[pi], 110.0);
+                        ys[pi] = clampAroundAnchor(ys[pi], tys[pi], 96.0);
+                    }
                 }
                 pi = pi + 1;
             }
@@ -403,10 +649,9 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                 src = edges[ei]["source"];
                 tgt = edges[ei]["target"];
                 if tgt in positions {
-                    if tgt not in contra_groups {
-                        contra_groups[tgt] = [];
-                    }
-                    contra_groups[tgt].append(src);
+                    contra_bucket: list = list(contra_groups[tgt]) if tgt in contra_groups else [];
+                    contra_bucket.append(src);
+                    contra_groups[tgt] = contra_bucket;
                 }
             }
             ei = ei + 1;
@@ -422,23 +667,25 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
                     src_id = contra_ids[cj];
                     src_box = getNodeBox(src_id);
                     tgt_box = getNodeBox(tgt_id);
-                    vertical_gap = max(110.0, (src_box["h"] + tgt_box["h"]) / 2.0 + 24.0);
+                    vertical_gap = max(88.0, (src_box["h"] + tgt_box["h"]) / 2.0 + 14.0);
                     target_pos = positions[tgt_id];
                     is_ghost_src = False;
+                    src_locked = False;
                     si = 0;
                     while si < len(nodes) {
                         if nodes[si]["id"] == src_id {
                             is_ghost_src = nodes[si]["isGhost"] if "isGhost" in nodes[si] else False;
+                            src_locked = nodes[si]["layoutLocked"] if "layoutLocked" in nodes[si] else False;
                             break;
                         }
                         si = si + 1;
                     }
                     extra_x = 120.0 if is_ghost_src else 0.0;
-                    if src_id in savedNodePositions {
+                    if src_locked and src_id in savedNodePositions {
                         positions[src_id] = savedNodePositions[src_id];
                     } else {
                         positions[src_id] = {
-                            "x": target_pos["x"] + 280.0 + extra_x,
+                            "x": target_pos["x"] + 252.0 + extra_x,
                             "y": target_pos["y"] + (cj - (len(contra_ids) - 1) / 2.0) * vertical_gap
                         };
                     }
@@ -448,7 +695,13 @@ def:pub ArgumentGraphView(props: any) -> JsxElement {
             ti = ti + 1;
         }
 
+        positions = spreadDenseLayerNeighbors(positions, ids, depths);
+        positions = resolveOverlapPositions(positions);
+
         nodePositions = positions;
+        if onLayoutResolved and positionsChanged(positions, savedNodePositions) {
+            onLayoutResolved(positions);
+        }
     }
 
     def getPos(nid: str) -> dict {

--- a/main.jac
+++ b/main.jac
@@ -3,7 +3,7 @@
 import from walkers.user_walkers { CreateUser, GetUserProfile, GetUserByEmail, UpdateUserProfile, GetCurrentUser }
 import from walkers.session_walkers { CreateSession, GetUserSessions, CalculateUserStats, DeleteSession, GetSessionGraph }
 import from walkers.graph_generate_walkers { GenerateArgumentGraph, GetGraphWithScoring }
-import from walkers.graph_revise_walkers { AddEvidenceToNode, AddAssumptionToEvidence, UpdateNodeContent, DeleteNode, AddCounterargumentNode, AddAddressEdge, EvaluateNewNode, GenerateCounter, ClarifyNode, InvestigateNode, ExpandBranch }
+import from walkers.graph_revise_walkers { AddEvidenceToNode, AddAssumptionToEvidence, UpdateNodeContent, DeleteNode, AddCounterargumentNode, AddAddressEdge, EvaluateNewNode, GenerateCounter, ClarifyNode, InvestigateNode, ExpandBranch, PersistGraphLayout, RestoreGraphSnapshot }
 
 cl import from .screens.AppRouter { AppRouter }
 

--- a/screens/ReviewScreen.cl.jac
+++ b/screens/ReviewScreen.cl.jac
@@ -19,6 +19,8 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         currentScore: dict = None,
         currentIssues: list = [],
         currentNextActions: list = [],
+        layoutHints: dict = {},
+        layoutHintGraphId: str = "",
         selectedNode: dict | None = None,
         focusBranch: str = None,
         editMode: str = "",
@@ -53,6 +55,10 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             if "score" in data { currentScore = data["score"]; }
             if "issues" in data { currentIssues = data["issues"]; }
             if "nextActions" in data { currentNextActions = data["nextActions"]; }
+            if graph_id != layoutHintGraphId {
+                layoutHints = {};
+                layoutHintGraphId = graph_id;
+            }
         } except Exception as e {
             print(f"ReviewScreen load error: {e}");
         }
@@ -73,6 +79,14 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             graph_id = currentGraph["id"] if "id" in currentGraph else "";
             ctx.setGraphCache(graph_id, suggestedCounterargs);
         }
+    }
+
+    def handleNodePositionsChange(updatedPositions: dict) -> None {
+        if currentGraph {
+            graph_id = currentGraph["id"] if "id" in currentGraph else "";
+            layoutHintGraphId = graph_id;
+        }
+        layoutHints = updatedPositions if updatedPositions else {};
     }
 
     def handleNodeClick(node_data: any) -> None {
@@ -1038,6 +1052,8 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                             selectedNodeId={selectedNode["id"] if selectedNode else None}
                             focusBranch={focusBranch}
                             onGhostAccept={handleAcceptCounterarg}
+                            layoutHints={layoutHints}
+                            onNodePositionsChange={handleNodePositionsChange}
                         />
                     </div>
 

--- a/screens/ReviewScreen.cl.jac
+++ b/screens/ReviewScreen.cl.jac
@@ -21,6 +21,10 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         currentNextActions: list = [],
         layoutHints: dict = {},
         layoutHintGraphId: str = "",
+        persistedLayoutPositions: dict = {},
+        persistedLayoutGraphId: str = "",
+        graphViewVersion: int = 0,
+        undoStack: list = [],
         selectedNode: dict | None = None,
         focusBranch: str = None,
         editMode: str = "",
@@ -51,14 +55,20 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         try {
             result = await root spawn GetGraphWithScoring(graphId=graph_id);
             data = result["reports"][0] if result["reports"] else {};
-            if "graph" in data { currentGraph = data["graph"]; }
+            if "graph" in data {
+                graph_data = data["graph"];
+                seed_positions = extractPositionsFromGraph(graph_data);
+                currentGraph = applyPositionsAndLocks(graph_data, seed_positions, {});
+                layoutHints = seed_positions;
+                layoutHintGraphId = graph_id;
+                persistedLayoutPositions = seed_positions;
+                persistedLayoutGraphId = graph_id;
+                graphViewVersion = graphViewVersion + 1;
+                undoStack = [];
+            }
             if "score" in data { currentScore = data["score"]; }
             if "issues" in data { currentIssues = data["issues"]; }
             if "nextActions" in data { currentNextActions = data["nextActions"]; }
-            if graph_id != layoutHintGraphId {
-                layoutHints = {};
-                layoutHintGraphId = graph_id;
-            }
         } except Exception as e {
             print(f"ReviewScreen load error: {e}");
         }
@@ -81,12 +91,447 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         }
     }
 
-    def handleNodePositionsChange(updatedPositions: dict) -> None {
-        if currentGraph {
-            graph_id = currentGraph["id"] if "id" in currentGraph else "";
-            layoutHintGraphId = graph_id;
+    def clonePositionMap(graph_data: dict, position_map: dict) -> dict {
+        result: dict = {};
+        if not graph_data or not position_map { return result; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            position_id = graph_nodes[gi]["id"] if "id" in graph_nodes[gi] else "";
+            if position_id in position_map {
+                raw_pos = position_map[position_id] if position_map[position_id] else {"x": 0, "y": 0};
+                result[position_id] = {
+                    "x": float(raw_pos["x"]) if "x" in raw_pos else 0.0,
+                    "y": float(raw_pos["y"]) if "y" in raw_pos else 0.0
+                };
+            }
+            gi = gi + 1;
         }
-        layoutHints = updatedPositions if updatedPositions else {};
+        return result;
+    }
+
+    def cloneNodeList(node_list: list) -> list {
+        result: list = [];
+        if not node_list { return result; }
+        ni = 0;
+        while ni < len(node_list) {
+            node_item = node_list[ni];
+            cloned = {
+                "id": node_item["id"] if "id" in node_item else "",
+                "type": node_item["type"] if "type" in node_item else "",
+                "content": node_item["content"] if "content" in node_item else "",
+                "confidence": node_item["confidence"] if "confidence" in node_item else 0.5,
+                "isWeak": node_item["isWeak"] if "isWeak" in node_item else False,
+                "issues": list(node_item["issues"]) if "issues" in node_item and node_item["issues"] else [],
+                "llmIssueTypes": list(node_item["llmIssueTypes"]) if "llmIssueTypes" in node_item and node_item["llmIssueTypes"] else [],
+                "position": {
+                    "x": float(node_item["position"]["x"]) if "position" in node_item and "x" in node_item["position"] else 0.0,
+                    "y": float(node_item["position"]["y"]) if "position" in node_item and "y" in node_item["position"] else 0.0
+                },
+                "evidence_category": node_item["evidence_category"] if "evidence_category" in node_item else "",
+                "assumptions": list(node_item["assumptions"]) if "assumptions" in node_item and node_item["assumptions"] else [],
+                "nodeScore": node_item["nodeScore"] if "nodeScore" in node_item else 50,
+                "sourceUrl": node_item["sourceUrl"] if "sourceUrl" in node_item else "",
+                "moreInfo": node_item["moreInfo"] if "moreInfo" in node_item else "",
+                "acknowledged": node_item["acknowledged"] if "acknowledged" in node_item else False,
+                "layoutLocked": node_item["layoutLocked"] if "layoutLocked" in node_item else False
+            };
+            if "isGhost" in node_item { cloned["isGhost"] = node_item["isGhost"]; }
+            if "ghostTarget" in node_item { cloned["ghostTarget"] = node_item["ghostTarget"]; }
+            result.append(cloned);
+            ni = ni + 1;
+        }
+        return result;
+    }
+
+    def cloneEdgeList(edge_list: list) -> list {
+        result: list = [];
+        if not edge_list { return result; }
+        ei = 0;
+        while ei < len(edge_list) {
+            edge_item = edge_list[ei];
+            cloned = {
+                "id": edge_item["id"] if "id" in edge_item else "",
+                "source": edge_item["source"] if "source" in edge_item else "",
+                "target": edge_item["target"] if "target" in edge_item else "",
+                "type": edge_item["type"] if "type" in edge_item else ""
+            };
+            if "weight" in edge_item { cloned["weight"] = edge_item["weight"]; }
+            if "reasoning_type" in edge_item { cloned["reasoning_type"] = edge_item["reasoning_type"]; }
+            if "isGhost" in edge_item { cloned["isGhost"] = edge_item["isGhost"]; }
+            result.append(cloned);
+            ei = ei + 1;
+        }
+        return result;
+    }
+
+    def cloneIssueList(issue_list: list) -> list {
+        result: list = [];
+        if not issue_list { return result; }
+        di = 0;
+        while di < len(issue_list) {
+            item = issue_list[di];
+            cloned = {
+                "id": item["id"] if "id" in item else "",
+                "nodeId": item["nodeId"] if "nodeId" in item else "",
+                "severity": item["severity"] if "severity" in item else "",
+                "type": item["type"] if "type" in item else "",
+                "description": item["description"] if "description" in item else "",
+                "suggestedAction": item["suggestedAction"] if "suggestedAction" in item else "",
+                "area": item["area"] if "area" in item else "",
+                "estimatedLift": item["estimatedLift"] if "estimatedLift" in item else 0
+            };
+            result.append(cloned);
+            di = di + 1;
+        }
+        return result;
+    }
+
+    def cloneNextActionList(action_list: list) -> list {
+        result: list = [];
+        if not action_list { return result; }
+        di = 0;
+        while di < len(action_list) {
+            item = action_list[di];
+            cloned = {
+                "id": item["id"] if "id" in item else "",
+                "nodeId": item["nodeId"] if "nodeId" in item else "",
+                "action": item["action"] if "action" in item else "",
+                "issueType": item["issueType"] if "issueType" in item else "",
+                "rank": item["rank"] if "rank" in item else 0,
+                "severity": item["severity"] if "severity" in item else "",
+                "area": item["area"] if "area" in item else "",
+                "expectedLift": item["expectedLift"] if "expectedLift" in item else 0
+            };
+            result.append(cloned);
+            di = di + 1;
+        }
+        return result;
+    }
+
+    def cloneScoreData(score_data: dict) -> dict {
+        if not score_data { return {}; }
+        return {
+            "overall": score_data["overall"] if "overall" in score_data else 0,
+            "support": score_data["support"] if "support" in score_data else 0,
+            "premise": score_data["premise"] if "premise" in score_data else 0,
+            "coherence": score_data["coherence"] if "coherence" in score_data else 0,
+            "counterargument": score_data["counterargument"] if "counterargument" in score_data else 0,
+            "consistency": score_data["consistency"] if "consistency" in score_data else 0,
+            "unsupportedClaims": score_data["unsupportedClaims"] if "unsupportedClaims" in score_data else 0,
+            "claimsNeedingPremise": score_data["claimsNeedingPremise"] if "claimsNeedingPremise" in score_data else 0,
+            "unresolvedContradictions": score_data["unresolvedContradictions"] if "unresolvedContradictions" in score_data else 0,
+            "weakInferenceClaims": score_data["weakInferenceClaims"] if "weakInferenceClaims" in score_data else 0,
+            "vagueClaims": score_data["vagueClaims"] if "vagueClaims" in score_data else 0,
+            "orphanNodes": score_data["orphanNodes"] if "orphanNodes" in score_data else 0,
+            "disconnectedClaims": score_data["disconnectedClaims"] if "disconnectedClaims" in score_data else 0,
+            "thesisSupported": score_data["thesisSupported"] if "thesisSupported" in score_data else False,
+            "passesBar": score_data["passesBar"] if "passesBar" in score_data else False
+        };
+    }
+
+    def cloneGraphData(graph_data: dict) -> dict {
+        if not graph_data { return None; }
+        return {
+            "id": graph_data["id"] if "id" in graph_data else "",
+            "nodes": cloneNodeList(graph_data["nodes"]) if "nodes" in graph_data else [],
+            "edges": cloneEdgeList(graph_data["edges"]) if "edges" in graph_data else [],
+            "createdAt": graph_data["createdAt"] if "createdAt" in graph_data else "",
+            "updatedAt": graph_data["updatedAt"] if "updatedAt" in graph_data else ""
+        };
+    }
+
+    def pushUndoSnapshot(actionLabel: str) -> None {
+        if not currentGraph { return; }
+        snapshot = {
+            "label": actionLabel,
+            "graph": cloneGraphData(currentGraph),
+            "score": cloneScoreData(currentScore) if currentScore else {},
+            "issues": cloneIssueList(currentIssues) if currentIssues else [],
+            "nextActions": cloneNextActionList(currentNextActions) if currentNextActions else [],
+            "layoutHints": clonePositionMap(currentGraph, getStableLayoutPositions()),
+            "persistedLayoutPositions": clonePositionMap(currentGraph, persistedLayoutPositions) if persistedLayoutPositions else clonePositionMap(currentGraph, extractPositionsFromGraph(currentGraph)),
+            "selectedNodeId": selectedNode["id"] if selectedNode and "id" in selectedNode else "",
+            "focusBranch": focusBranch if focusBranch else "",
+            "dismissedCounterargTexts": list(dismissedCounterargTexts) if dismissedCounterargTexts else []
+        };
+        next_stack = list(undoStack);
+        next_stack.append(snapshot);
+        if len(next_stack) > 20 {
+            next_stack = next_stack[1:];
+        }
+        undoStack = next_stack;
+    }
+
+    def findNodeById(graph_data: dict, node_id: str) -> dict | None {
+        if not graph_data or not node_id { return None; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            if graph_nodes[gi]["id"] == node_id {
+                return graph_nodes[gi];
+            }
+            gi = gi + 1;
+        }
+        return None;
+    }
+
+    def extractPositionsFromGraph(graph_data: dict) -> dict {
+        result: dict = {};
+        if not graph_data or "nodes" not in graph_data { return result; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            graph_pos = graph_node["position"] if "position" in graph_node else {"x": 0, "y": 0};
+            result[graph_id] = {
+                "x": float(graph_pos["x"]) if "x" in graph_pos else 0.0,
+                "y": float(graph_pos["y"]) if "y" in graph_pos else 0.0
+            };
+            gi = gi + 1;
+        }
+        return result;
+    }
+
+    def extractNodeIdMap(graph_data: dict) -> dict {
+        result: dict = {};
+        if not graph_data or "nodes" not in graph_data { return result; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            if graph_id { result[graph_id] = True; }
+            gi = gi + 1;
+        }
+        return result;
+    }
+
+    def extractLockedNodeIdMap(graph_data: dict) -> dict {
+        result: dict = {};
+        if not graph_data or "nodes" not in graph_data { return result; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            is_locked = graph_node["layoutLocked"] if "layoutLocked" in graph_node else False;
+            if graph_id and is_locked {
+                result[graph_id] = True;
+            }
+            gi = gi + 1;
+        }
+        return result;
+    }
+
+    def extractMovedNodeIdMap(graph_data: dict, candidate_positions: dict) -> dict {
+        result = extractLockedNodeIdMap(graph_data);
+        if not graph_data or not candidate_positions { return result; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            if graph_id and graph_id in candidate_positions {
+                graph_pos = graph_node["position"] if "position" in graph_node else {"x": 0, "y": 0};
+                next_pos = candidate_positions[graph_id] if candidate_positions[graph_id] else {"x": 0, "y": 0};
+                graph_x = float(graph_pos["x"]) if "x" in graph_pos else 0.0;
+                graph_y = float(graph_pos["y"]) if "y" in graph_pos else 0.0;
+                next_x = float(next_pos["x"]) if "x" in next_pos else 0.0;
+                next_y = float(next_pos["y"]) if "y" in next_pos else 0.0;
+                if abs(graph_x - next_x) > 0.5 or abs(graph_y - next_y) > 0.5 {
+                    result[graph_id] = True;
+                }
+            }
+            gi = gi + 1;
+        }
+        return result;
+    }
+
+    def positionsDifferFromGraph(graph_data: dict, candidate_positions: dict) -> bool {
+        if not graph_data { return False; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            if graph_id not in candidate_positions {
+                return True;
+            }
+            graph_pos = graph_node["position"] if "position" in graph_node else {"x": 0, "y": 0};
+            next_pos = candidate_positions[graph_id] if candidate_positions[graph_id] else {"x": 0, "y": 0};
+            graph_x = float(graph_pos["x"]) if "x" in graph_pos else 0.0;
+            graph_y = float(graph_pos["y"]) if "y" in graph_pos else 0.0;
+            next_x = float(next_pos["x"]) if "x" in next_pos else 0.0;
+            next_y = float(next_pos["y"]) if "y" in next_pos else 0.0;
+            if abs(graph_x - next_x) > 0.5 or abs(graph_y - next_y) > 0.5 {
+                return True;
+            }
+            gi = gi + 1;
+        }
+        return False;
+    }
+
+    def positionsDifferFromSnapshot(graph_data: dict, candidate_positions: dict, baseline_positions: dict) -> bool {
+        if not graph_data { return False; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            if graph_id not in candidate_positions or graph_id not in baseline_positions {
+                return True;
+            }
+            base_pos = baseline_positions[graph_id] if baseline_positions[graph_id] else {"x": 0, "y": 0};
+            next_pos = candidate_positions[graph_id] if candidate_positions[graph_id] else {"x": 0, "y": 0};
+            base_x = float(base_pos["x"]) if "x" in base_pos else 0.0;
+            base_y = float(base_pos["y"]) if "y" in base_pos else 0.0;
+            next_x = float(next_pos["x"]) if "x" in next_pos else 0.0;
+            next_y = float(next_pos["y"]) if "y" in next_pos else 0.0;
+            if abs(base_x - next_x) > 0.5 or abs(base_y - next_y) > 0.5 {
+                return True;
+            }
+            gi = gi + 1;
+        }
+        return False;
+    }
+
+    def applyPositionsAndLocks(graph_data: dict, preferred_positions: dict = {}, locked_node_ids: dict = {}) -> dict {
+        if not graph_data { return graph_data; }
+        graph_nodes = graph_data["nodes"] if "nodes" in graph_data else [];
+        gi = 0;
+        while gi < len(graph_nodes) {
+            graph_node = graph_nodes[gi];
+            graph_id = graph_node["id"] if "id" in graph_node else "";
+            if graph_id in preferred_positions {
+                graph_node["position"] = preferred_positions[graph_id];
+            } elif "position" not in graph_node {
+                graph_node["position"] = {"x": 0, "y": 0};
+            }
+            graph_node["layoutLocked"] = graph_id in locked_node_ids;
+            graph_nodes[gi] = graph_node;
+            gi = gi + 1;
+        }
+        graph_data["nodes"] = graph_nodes;
+        return graph_data;
+    }
+
+    def getStableLayoutPositions() -> dict {
+        if layoutHints and len(layoutHints) > 0 {
+            return layoutHints;
+        }
+        return extractPositionsFromGraph(currentGraph);
+    }
+
+    async def flushLayoutToBackend(force: bool = False) -> None {
+        if not currentGraph { return; }
+        next_positions = getStableLayoutPositions();
+        baseline_positions = persistedLayoutPositions if persistedLayoutGraphId == (currentGraph["id"] if currentGraph and "id" in currentGraph else "") else extractPositionsFromGraph(currentGraph);
+        if not force and not positionsDifferFromSnapshot(currentGraph, next_positions, baseline_positions) {
+            return;
+        }
+        graph_id = currentGraph["id"] if "id" in currentGraph else "";
+        if not graph_id { return; }
+        locked_node_ids = extractLockedNodeIdMap(currentGraph);
+        try {
+            persistResult = await root spawn PersistGraphLayout(graphId=graph_id, positions=next_positions);
+            persistData = persistResult["reports"][0] if persistResult["reports"] else {};
+            if "graph" in persistData {
+                currentGraph = applyPositionsAndLocks(
+                    persistData["graph"],
+                    next_positions,
+                    locked_node_ids
+                );
+            } else {
+                currentGraph = applyPositionsAndLocks(
+                    currentGraph,
+                    next_positions,
+                    locked_node_ids
+                );
+            }
+            layoutHints = next_positions;
+            layoutHintGraphId = graph_id;
+            persistedLayoutPositions = next_positions;
+            persistedLayoutGraphId = graph_id;
+        } except Exception as e {
+            print(f"ReviewScreen layout persist error: {e}");
+        }
+    }
+
+    def applyMutationGraph(mutData: dict, preserved_positions: dict, preserved_node_ids: dict) -> dict {
+        if "graph" not in mutData { return currentGraph; }
+        next_graph = mutData["graph"];
+        next_graph = applyPositionsAndLocks(next_graph, preserved_positions, preserved_node_ids);
+        currentGraph = next_graph;
+        layoutHints = extractPositionsFromGraph(next_graph);
+        layoutHintGraphId = next_graph["id"] if "id" in next_graph else layoutHintGraphId;
+        persistedLayoutPositions = extractPositionsFromGraph(next_graph);
+        persistedLayoutGraphId = next_graph["id"] if "id" in next_graph else persistedLayoutGraphId;
+        return next_graph;
+    }
+
+    def syncLayoutLocally(updatedPositions: dict, lock_all_nodes: bool = False) -> None {
+        if not currentGraph or not updatedPositions { return; }
+        locked_ids = extractMovedNodeIdMap(currentGraph, updatedPositions) if lock_all_nodes else extractLockedNodeIdMap(currentGraph);
+        currentGraph = applyPositionsAndLocks(currentGraph, updatedPositions, locked_ids);
+        layoutHints = updatedPositions;
+        graph_id = currentGraph["id"] if "id" in currentGraph else "";
+        layoutHintGraphId = graph_id;
+    }
+
+    def handleLayoutResolved(resolvedPositions: dict) -> None {
+        if not resolvedPositions or not currentGraph { return; }
+        if not positionsDifferFromGraph(currentGraph, resolvedPositions) { return; }
+        syncLayoutLocally(resolvedPositions, False);
+    }
+
+    async def handleNodePositionsChange(updatedPositions: dict) -> None {
+        if not updatedPositions or not currentGraph { return; }
+        pushUndoSnapshot("Move node");
+        syncLayoutLocally(updatedPositions, True);
+        await flushLayoutToBackend(True);
+    }
+
+    async def handleUndo() -> None {
+        if len(undoStack) == 0 or not currentGraph { return; }
+        last_index = len(undoStack) - 1;
+        snapshot = undoStack[last_index];
+        next_stack = list(undoStack[:last_index]);
+        graph_snapshot = snapshot["graph"] if "graph" in snapshot else None;
+        if not graph_snapshot { return; }
+
+        isSaving = True;
+        try {
+            restoreResult = await root spawn RestoreGraphSnapshot(
+                graphId=graph_snapshot["id"] if "id" in graph_snapshot else "",
+                nodes=graph_snapshot["nodes"] if "nodes" in graph_snapshot else [],
+                edges=graph_snapshot["edges"] if "edges" in graph_snapshot else []
+            );
+            restoreData = restoreResult["reports"][0] if restoreResult["reports"] else {};
+
+            if "graph" in restoreData {
+                restored_graph = restoreData["graph"];
+                restored_positions = snapshot["layoutHints"] if "layoutHints" in snapshot else extractPositionsFromGraph(restored_graph);
+                currentGraph = applyPositionsAndLocks(restored_graph, restored_positions, extractLockedNodeIdMap(graph_snapshot));
+                currentScore = restoreData["score"] if "score" in restoreData else (snapshot["score"] if "score" in snapshot else {});
+                currentIssues = restoreData["issues"] if "issues" in restoreData else (snapshot["issues"] if "issues" in snapshot else []);
+                currentNextActions = restoreData["nextActions"] if "nextActions" in restoreData else (snapshot["nextActions"] if "nextActions" in snapshot else []);
+                layoutHints = restored_positions;
+                layoutHintGraphId = restored_graph["id"] if "id" in restored_graph else layoutHintGraphId;
+                persistedLayoutPositions = snapshot["persistedLayoutPositions"] if "persistedLayoutPositions" in snapshot else restored_positions;
+                persistedLayoutGraphId = restored_graph["id"] if "id" in restored_graph else persistedLayoutGraphId;
+                graphViewVersion = graphViewVersion + 1;
+                dismissedCounterargTexts = snapshot["dismissedCounterargTexts"] if "dismissedCounterargTexts" in snapshot else [];
+                focusBranch = snapshot["focusBranch"] if "focusBranch" in snapshot else "";
+                selectedNode = findNodeById(currentGraph, snapshot["selectedNodeId"] if "selectedNodeId" in snapshot else "");
+                undoStack = next_stack;
+            }
+        } except Exception as e {
+            print(f"ReviewScreen undo error: {e}");
+        }
+        isSaving = False;
+        pushUpdate();
     }
 
     def handleNodeClick(node_data: any) -> None {
@@ -182,13 +627,17 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     async def handleGenerateCounter() -> None {
         if not selectedNode or not currentGraph { return; }
         isSaving = True;
+        pushUndoSnapshot("Generate counter");
         _gcGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _gcNodeId = selectedNode["id"];
         _gcPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _gcPreservedPositions = getStableLayoutPositions();
+        _gcPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn GenerateCounter(graphId=_gcGraphId, targetNodeId=_gcNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            _freshGraph = applyMutationGraph(mutData, _gcPreservedPositions, _gcPreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _gcNewScore = currentScore["overall"] if "overall" in currentScore else _gcPrevScore;
@@ -196,7 +645,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if "issues" in mutData { currentIssues = mutData["issues"]; }
             if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
             _gcNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
             _gcFound = None;
             _gci = 0;
@@ -236,17 +684,21 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     async def handlePickInvestigateResult(resultIndex: int, pickedTitle: str, pickedUrl: str) -> None {
         if not selectedNode or not currentGraph { return; }
         isSaving = True;
+        pushUndoSnapshot("Add investigated evidence");
         _pirGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _pirNodeId = selectedNode["id"];
         _pirPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _pirPreservedPositions = getStableLayoutPositions();
+        _pirPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn InvestigateNode(
                 graphId=_pirGraphId, nodeId=_pirNodeId,
                 selectedResultIndex=resultIndex, addAsEvidence=True,
                 selectedTitle=pickedTitle, selectedUrl=pickedUrl
             );
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            _freshGraph = applyMutationGraph(mutData, _pirPreservedPositions, _pirPreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _pirNewScore = currentScore["overall"] if "overall" in currentScore else _pirPrevScore;
@@ -254,7 +706,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if "issues" in mutData { currentIssues = mutData["issues"]; }
             if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
             _pirNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
             _pirFound = None;
             _piri = 0;
@@ -285,13 +736,17 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     async def handleAutoFix() -> None {
         if not selectedNode or not currentGraph { return; }
         isSaving = True;
+        pushUndoSnapshot("Auto-fix node");
         _afGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _afNodeId = selectedNode["id"];
         _afPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _afPreservedPositions = getStableLayoutPositions();
+        _afPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn InvestigateNode(graphId=_afGraphId, nodeId=_afNodeId, addAsEvidence=True);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            _freshGraph = applyMutationGraph(mutData, _afPreservedPositions, _afPreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _afNewScore = currentScore["overall"] if "overall" in currentScore else _afPrevScore;
@@ -299,7 +754,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if "issues" in mutData { currentIssues = mutData["issues"]; }
             if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
             _afNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
             _afFound = None;
             _afi = 0;
@@ -320,16 +774,20 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         _aeSourceUrl = selectedNode["sourceUrl"] if "sourceUrl" in selectedNode else "";
         if not _aeMoreInfo { return; }
         isSaving = True;
+        pushUndoSnapshot("Add evidence");
         _aeGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _aeNodeId = selectedNode["id"];
         _aePrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _aePreservedPositions = getStableLayoutPositions();
+        _aePreservedNodeIds = extractLockedNodeIdMap(currentGraph);
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn AddEvidenceToNode(
                 graphId=_aeGraphId, nodeId=_aeNodeId,
                 evidenceContent=_aeMoreInfo, sourceUrl=_aeSourceUrl
             );
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            _freshGraph = applyMutationGraph(mutData, _aePreservedPositions, _aePreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _aeNewScore = currentScore["overall"] if "overall" in currentScore else _aePrevScore;
@@ -337,7 +795,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if "issues" in mutData { currentIssues = mutData["issues"]; }
             if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
             _aeNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
             _aeFound = None;
             _aei = 0;
@@ -383,11 +840,20 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     async def saveEdit() -> None {
         if not editInputValue.strip() or not selectedNode or not currentGraph { return; }
         isSaving = True;
+        _undo_label = "Edit graph";
+        if editMode == "address" {
+            _undo_label = "Add response";
+        } elif editMode == "evidence" or editMode == "respond" {
+            _undo_label = "Add evidence";
+        }
+        pushUndoSnapshot(_undo_label);
         _seGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _seNodeId = selectedNode["id"];
         _seMode = editMode;
         _seContent = editInputValue.strip();
         _sePrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _sePreservedPositions = getStableLayoutPositions();
+        _sePreservedNodeIds = extractLockedNodeIdMap(currentGraph);
 
         _seDefendId = "";
         if _seMode == "address" {
@@ -407,6 +873,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         }
 
         try {
+            await flushLayoutToBackend();
             mutResult = None;
             if _seMode == "evidence" or _seMode == "respond" {
                 _seSourceUrl = sourceUrlValue.strip() if sourceUrlValue else "";
@@ -423,7 +890,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if mutResult {
                 mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-                if "graph" in mutData { currentGraph = mutData["graph"]; }
+                _freshGraph = applyMutationGraph(mutData, _sePreservedPositions, _sePreservedNodeIds);
                 if "score" in mutData {
                     currentScore = mutData["score"];
                     _seNewScore = currentScore["overall"] if "overall" in currentScore else _sePrevScore;
@@ -431,7 +898,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                 }
                 if "issues" in mutData { currentIssues = mutData["issues"]; }
                 if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-                _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
                 _seNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
                 _seFound = None;
                 _sefi = 0;
@@ -454,6 +920,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         if not currentGraph { return; }
         _delNodeId = selectedNode["id"] if selectedNode and "id" in selectedNode else "";
         if not _delNodeId { return; }
+        pushUndoSnapshot("Delete node");
         _delNodeType = selectedNode["type"] if selectedNode and "type" in selectedNode else "";
         _delNodeContent = selectedNode["content"] if selectedNode and "content" in selectedNode else "";
 
@@ -480,11 +947,14 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         isSaving = True;
         _delPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
         _delGraphId = currentGraph["id"] if "id" in currentGraph else "";
+        _delPreservedPositions = getStableLayoutPositions();
+        _delPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
 
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn DeleteNode(graphId=_delGraphId, nodeId=_delNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            applyMutationGraph(mutData, _delPreservedPositions, _delPreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _delNewScore = currentScore["overall"] if "overall" in currentScore else _delPrevScore;
@@ -531,15 +1001,19 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         if not ca_text or not ca_target { return; }
 
         isSaving = True;
+        pushUndoSnapshot("Add counterargument");
         _acGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _acPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _acPreservedPositions = getStableLayoutPositions();
+        _acPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
 
         try {
+            await flushLayoutToBackend();
             addResult = await root spawn AddCounterargumentNode(
                 graphId=_acGraphId, targetNodeId=ca_target, counterargContent=ca_text
             );
             addData = addResult["reports"][0] if addResult["reports"] else {};
-            if "graph" in addData { currentGraph = addData["graph"]; }
+            applyMutationGraph(addData, _acPreservedPositions, _acPreservedNodeIds);
             if "score" in addData {
                 currentScore = addData["score"];
                 _acNewScore = currentScore["overall"] if "overall" in currentScore else _acPrevScore;
@@ -556,13 +1030,17 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     async def handleExpandBranch() -> None {
         if not selectedNode or not currentGraph { return; }
         isSaving = True;
+        pushUndoSnapshot("Expand branch");
         _ebGraphId = currentGraph["id"] if "id" in currentGraph else "";
         _ebNodeId = selectedNode["id"];
         _ebPrevScore = currentScore["overall"] if currentScore and "overall" in currentScore else 0;
+        _ebPreservedPositions = getStableLayoutPositions();
+        _ebPreservedNodeIds = extractLockedNodeIdMap(currentGraph);
         try {
+            await flushLayoutToBackend();
             mutResult = await root spawn ExpandBranch(graphId=_ebGraphId, nodeId=_ebNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
+            _freshGraph = applyMutationGraph(mutData, _ebPreservedPositions, _ebPreservedNodeIds);
             if "score" in mutData {
                 currentScore = mutData["score"];
                 _ebNewScore = currentScore["overall"] if "overall" in currentScore else _ebPrevScore;
@@ -570,7 +1048,6 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if "issues" in mutData { currentIssues = mutData["issues"]; }
             if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
             _ebNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
             _ebFound = None;
             _ebi = 0;
@@ -965,8 +1442,11 @@ def:pub ReviewScreen(props: any) -> JsxElement {
     graph_edges = currentGraph["edges"] if "edges" in currentGraph else [];
     allNodes = list(graph_nodes) + ghostNodes;
     allEdges = list(graph_edges) + ghostEdges;
+    graph_view_key = f"{currentGraph['id'] if 'id' in currentGraph else 'graph'}:{graphViewVersion}";
     node_count_str = str(len(graph_nodes)) if graph_nodes else "0";
     edge_count_str = str(len(graph_edges)) if graph_edges else "0";
+    has_undo = len(undoStack) > 0;
+    last_undo_label = undoStack[len(undoStack) - 1]["label"] if has_undo and "label" in undoStack[len(undoStack) - 1] else "last change";
 
     saving_overlay_display = "flex" if isSaving else "none";
 
@@ -1046,6 +1526,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
 
                     <div className="rs-graph-wrapper">
                         <ArgumentGraphView
+                            key={graph_view_key}
                             nodes={allNodes}
                             edges={allEdges}
                             onNodeClick={handleNodeClick}
@@ -1053,6 +1534,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                             focusBranch={focusBranch}
                             onGhostAccept={handleAcceptCounterarg}
                             layoutHints={layoutHints}
+                            onLayoutResolved={handleLayoutResolved}
                             onNodePositionsChange={handleNodePositionsChange}
                         />
                     </div>
@@ -1062,6 +1544,13 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                         <span className="rs-statusbar-text">
                             {node_count_str} nodes - {edge_count_str} edges
                         </span>
+                        <div style={{"flex": "1"}}></div>
+                        <Button
+                            label={f"Undo {last_undo_label}" if has_undo else "Undo"}
+                            onClick={handleUndo}
+                            variant="secondary"
+                            disabled={not has_undo or isSaving}
+                        />
                     </div>
 
                     {(
@@ -1262,7 +1751,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                                 <div className="rs-delete-box">
                                     <div className="rs-delete-title">Delete this node?</div>
                                     <div className="rs-delete-warning">
-                                        This will remove the node and all its connections.
+                                        This will remove the node and all its connections. You can undo this from the review toolbar.
                                     </div>
                                     <div className="rs-edit-buttons">
                                         <button className="rs-confirm-delete-btn"

--- a/walkers/graph_revise_walkers.jac
+++ b/walkers/graph_revise_walkers.jac
@@ -8,6 +8,133 @@ import json;
 import urllib.request;
 import urllib.parse;
 
+walker:pub PersistGraphLayout {
+    has graphId: str,
+        positions: dict = {};
+
+    can run with Root entry {
+        try {
+        graph_node = None;
+        for graph in [-->](?:ArgumentGraph) {
+            if graph.id == self.graphId {
+                graph_node = graph;
+                break;
+            }
+        }
+
+        if not graph_node {
+            report {"error": "Graph not found"};
+            return;
+        }
+
+        pos_map = self.positions if self.positions else {};
+        updated_nodes: list = [];
+        updated_count = 0;
+
+        for node in graph_node.nodes {
+            node_id = node.get("id", "");
+            if node_id in pos_map {
+                raw_pos = pos_map[node_id] if pos_map[node_id] else {};
+                existing_pos = node.get("position", {"x": 0, "y": 0});
+                next_x = 0.0;
+                next_y = 0.0;
+
+                try {
+                    next_x = float(raw_pos.get("x", existing_pos.get("x", 0)));
+                } except Exception {
+                    next_x = float(existing_pos.get("x", 0));
+                }
+                try {
+                    next_y = float(raw_pos.get("y", existing_pos.get("y", 0)));
+                } except Exception {
+                    next_y = float(existing_pos.get("y", 0));
+                }
+
+                updated_node = {
+                    "id": node.get("id", ""),
+                    "type": node.get("type", ""),
+                    "content": node.get("content", ""),
+                    "confidence": node.get("confidence", 0.5),
+                    "isWeak": node.get("isWeak", False),
+                    "issues": node.get("issues", []),
+                    "llmIssueTypes": node.get("llmIssueTypes", []),
+                    "position": {"x": next_x, "y": next_y},
+                    "evidence_category": node.get("evidence_category", ""),
+                    "assumptions": node.get("assumptions", []),
+                    "nodeScore": node.get("nodeScore", 50),
+                    "sourceUrl": node.get("sourceUrl", ""),
+                    "moreInfo": node.get("moreInfo", ""),
+                    "acknowledged": node.get("acknowledged", False)
+                };
+                updated_nodes.append(updated_node);
+                updated_count = updated_count + 1;
+                continue;
+            }
+            updated_nodes.append(node);
+        }
+
+        graph_node.nodes = updated_nodes;
+        graph_node.updatedAt = str(int(time.time()));
+
+        report {
+            "success": True,
+            "updatedCount": updated_count,
+            "graph": {
+                "id": graph_node.id,
+                "nodes": graph_node.nodes,
+                "edges": graph_node.edges,
+                "createdAt": graph_node.createdAt,
+                "updatedAt": graph_node.updatedAt
+            }
+        };
+        } except Exception as e {
+            print(f"PersistGraphLayout ERROR: {e}");
+            report {"error": str(e)};
+        }
+    }
+}
+
+walker:pub RestoreGraphSnapshot {
+    has graphId: str,
+        nodes: list = [],
+        edges: list = [];
+
+    can run with Root entry {
+        try {
+        graph_node = None;
+        for graph in [-->](?:ArgumentGraph) {
+            if graph.id == self.graphId {
+                graph_node = graph;
+                break;
+            }
+        }
+
+        if not graph_node {
+            report {"error": "Graph not found"};
+            return;
+        }
+
+        graph_node.nodes = list(self.nodes) if self.nodes else [];
+        graph_node.edges = list(self.edges) if self.edges else [];
+        graph_node.updatedAt = str(int(time.time()));
+
+        scorer = GetGraphWithScoring(graphId=self.graphId);
+        scored_data = scorer.score_graph(graph_node);
+
+        report {
+            "success": True,
+            "graph": scored_data.get("graph", {"id": graph_node.id, "nodes": graph_node.nodes, "edges": graph_node.edges, "createdAt": graph_node.createdAt, "updatedAt": graph_node.updatedAt}),
+            "score": scored_data.get("score", {}),
+            "issues": scored_data.get("issues", []),
+            "nextActions": scored_data.get("nextActions", [])
+        };
+        } except Exception as e {
+            print(f"RestoreGraphSnapshot ERROR: {e}");
+            report {"error": str(e)};
+        }
+    }
+}
+
 walker:pub AddEvidenceToNode {
     has graphId: str,
         nodeId: str,


### PR DESCRIPTION

preserves review graph layout across drag, relayout, and undo flows
- makes undo for moved nodes reliable during review editing
- reduces local node overlap after expand/counter without over-expanding the whole graph

Scope
- review graph layout behavior only
- excludes local-only `jac.toml` model changes
Notes
- keeps dragged nodes stable while letting nearby nodes make room locally
- branch: `justin/graph-layout-stability-v2`