### PR TITLE
Rely on root-scoped isolation instead of manual userId filtering

### DIFF
--- a/graph/session_nodes.jac
+++ b/graph/session_nodes.jac
@@ -6,6 +6,5 @@ node Session {
         title: str,
         initialScore: int,
         finalScore: int,
-        userId: str = "",
         notes: str = "";
 }

--- a/graph/user_nodes.jac
+++ b/graph/user_nodes.jac
@@ -10,6 +10,5 @@ node User {
         strengths: list[str] = [],
         weaknesses: list[str] = [],
         theme: str = "light",
-        accessibilityMode: bool = False,
-        isGuest: bool = False;
+        accessibilityMode: bool = False;
 }

--- a/main.jac
+++ b/main.jac
@@ -1,14 +1,41 @@
 """Main entry point for maizemind."""
 
-import from walkers.user_walkers { CreateUser, GetUserProfile, GetUserByEmail, UpdateUserProfile, GetCurrentUser }
-import from walkers.session_walkers { CreateSession, GetUserSessions, CalculateUserStats, DeleteSession, GetSessionGraph }
-import from walkers.graph_generate_walkers { GenerateArgumentGraph, GetGraphWithScoring }
-import from walkers.graph_revise_walkers { AddEvidenceToNode, AddAssumptionToEvidence, UpdateNodeContent, DeleteNode, AddCounterargumentNode, AddAddressEdge, EvaluateNewNode, GenerateCounter, ClarifyNode, InvestigateNode, ExpandBranch }
+import from walkers.user_walkers {
+    CreateUser,
+    GetUserProfile,
+    GetUserByEmail,
+    UpdateUserProfile,
+    GetCurrentUser
+}
+import from walkers.session_walkers {
+    CreateSession,
+    GetUserSessions,
+    CalculateUserStats,
+    DeleteSession,
+    GetSessionGraph
+}
+import from walkers.graph_generate_walkers {
+    GenerateArgumentGraph,
+    GetGraphWithScoring
+}
+import from walkers.graph_revise_walkers {
+    AddEvidenceToNode,
+    AddAssumptionToEvidence,
+    UpdateNodeContent,
+    DeleteNode,
+    AddCounterargumentNode,
+    AddAddressEdge,
+    EvaluateNewNode,
+    GenerateCounter,
+    ClarifyNode,
+    InvestigateNode,
+    ExpandBranch
+}
 
 cl import from .screens.AppRouter { AppRouter }
 
 cl {
     def:pub app -> JsxElement {
-        return <AppRouter />;
+        return <AppRouter/>;
     }
 }

--- a/screens/ExportScreen.cl.jac
+++ b/screens/ExportScreen.cl.jac
@@ -362,7 +362,6 @@ def:pub ExportScreen(props: any) -> JsxElement {
         if not ctx.userId or not ctx.isLoggedIn or saved { return; }
         graphId = currentGraph["id"] if currentGraph and "id" in currentGraph else "";
         await root spawn CreateSession(
-            userId=ctx.userId,
             graphId=graphId,
             notes="",
             score=currentScore

--- a/screens/GenerateScreen.cl.jac
+++ b/screens/GenerateScreen.cl.jac
@@ -56,8 +56,7 @@ def:pub GenerateScreen(props: any) -> JsxElement {
         try {
             combined_uploaded = uploadedFiles.map(lambda f -> any { return f["content"]; }).join("\n");
             result = await root spawn GenerateArgumentGraph(
-                notes=notes + combined_uploaded,
-                userId=currentUserId
+                notes=notes + combined_uploaded
             );
 
             data = result["reports"][0] if result["reports"] else {};

--- a/screens/ProfileScreen.cl.jac
+++ b/screens/ProfileScreen.cl.jac
@@ -45,7 +45,7 @@ def:pub ProfileScreen(props: any) -> JsxElement {
         }
 
         try {
-            result = await root spawn GetUserByEmail(email=ctx.userEmail);
+            result = await root spawn GetUserByEmail();
             data = result["reports"][0] if result["reports"] else {};
 
             if not data or "id" not in data {
@@ -65,7 +65,7 @@ def:pub ProfileScreen(props: any) -> JsxElement {
 
             if local_userId {
                 try {
-                    sess_result = await root spawn GetUserSessions(userId=local_userId);
+                    sess_result = await root spawn GetUserSessions();
                     raw_sessions = sess_result["reports"][0] if sess_result["reports"] else [];
                     sessions = raw_sessions if raw_sessions else [];
                 } except Exception as e {
@@ -73,7 +73,7 @@ def:pub ProfileScreen(props: any) -> JsxElement {
                 }
 
                 try {
-                    stats_result = await root spawn CalculateUserStats(userId=local_userId);
+                    stats_result = await root spawn CalculateUserStats();
                     local_stats = stats_result["reports"][0] if stats_result["reports"] else None;
                 } except Exception as e {
                     print(f"Error loading stats: {e}");
@@ -104,7 +104,6 @@ def:pub ProfileScreen(props: any) -> JsxElement {
 
     async def handleSaveProfile() -> None {
         await root spawn UpdateUserProfile(
-            userId=userId,
             name=name,
             userType=userType,
             goals=goals,
@@ -116,7 +115,6 @@ def:pub ProfileScreen(props: any) -> JsxElement {
     async def handleSaveTheme(new_theme: str) -> None {
         theme = new_theme;
         await root spawn UpdateUserProfile(
-            userId=userId,
             name=name,
             userType=userType,
             goals=goals,
@@ -126,9 +124,8 @@ def:pub ProfileScreen(props: any) -> JsxElement {
     }
 
     async def handleOpenSession(sessionId: str) -> None {
-        local_userId = userId;
         try {
-            result = await root spawn GetSessionGraph(sessionId=sessionId, userId=local_userId);
+            result = await root spawn GetSessionGraph(sessionId=sessionId);
             data = result["reports"][0] if result["reports"] else {};
             if "error" in data {
                 print(f"GetSessionGraph error: {data['error']}");
@@ -187,8 +184,7 @@ def:pub ProfileScreen(props: any) -> JsxElement {
     }
 
     async def handleDeleteSession(sessionId: str) -> None {
-        local_userId = userId;
-        await root spawn DeleteSession(sessionId=sessionId, userId=local_userId);
+        await root spawn DeleteSession(sessionId=sessionId);
         confirmDeleteSessionId = "";
         loadContext();
     }

--- a/screens/WelcomeScreen.cl.jac
+++ b/screens/WelcomeScreen.cl.jac
@@ -74,16 +74,6 @@ def:pub WelcomeScreen(props: any) -> JsxElement {
 
         loading = True;
 
-        try {
-            existing_result = await root spawn GetUserByEmail(email=email);
-            existing_user = existing_result["reports"][0] if existing_result["reports"] else None;
-            if existing_user and "id" in existing_user {
-                error = "An account with this email already exists. Please log in instead.";
-                loading = False;
-                return;
-            }
-        } except Exception {}
-
         signup_result = await jacSignup(email, password);
         if not signup_result["success"] {
             error = signup_result["error"] if "error" in signup_result else "Signup failed";
@@ -102,15 +92,9 @@ def:pub WelcomeScreen(props: any) -> JsxElement {
         try {
             result = await root spawn CreateUser(
                 name=name if name else email.split("@")[0],
-                email=email,
-                isGuest=False
+                email=email
             );
             user_data = result["reports"][0] if result["reports"] else {};
-            if "error" in user_data and user_data["error"] == "account_exists" {
-                error = "An account with this email already exists. Please log in instead.";
-                loading = False;
-                return;
-            }
             userId = user_data["id"] if "id" in user_data else "";
         } except Exception {}
 
@@ -140,7 +124,7 @@ def:pub WelcomeScreen(props: any) -> JsxElement {
         password = "";
 
         try {
-            result = await root spawn GetUserByEmail(email=saved_email);
+            result = await root spawn GetUserByEmail();
             user_data = result["reports"][0] if result["reports"] else {};
             if user_data and "id" in user_data {
                 is_dark = "theme" in user_data and user_data["theme"] == "dark";

--- a/walkers/graph_generate_walkers.jac
+++ b/walkers/graph_generate_walkers.jac
@@ -4,12 +4,11 @@ import from graph.argument_graph_nodes { ArgumentGraph }
 import from src.graph_generator { Document, generate_argument_graph }
 
 walker:pub GenerateArgumentGraph {
-    has notes: str,
-        userId: str;
+    has notes: str;
 
     can run with Root entry {
         print("=== GenerateArgumentGraph ENTERED ===");
-        print(f"=== userId={self.userId}, notes length={len(self.notes)} ===");
+        print(f"=== notes length={len(self.notes)} ===");
         try {
         import time;
         graph_id = f"graph_{int(time.time())}";

--- a/walkers/session_walkers.jac
+++ b/walkers/session_walkers.jac
@@ -4,9 +4,8 @@ import from datetime { datetime }
 import from graph.session_nodes { Session }
 import from graph.argument_graph_nodes { ArgumentGraph }
 
-walker:pub CreateSession {
-    has userId: str,
-        graphId: str,
+walker:priv CreateSession {
+    has graphId: str,
         notes: str,
         score: dict;
 
@@ -35,7 +34,6 @@ walker:pub CreateSession {
         new_session = (root ++> Session(
             id=f"session_{timestamp}",
             date=str(datetime.now().isoformat()),
-            userId=self.userId,
             title=title,
             initialScore=self.score["overall"],
             finalScore=self.score["overall"],
@@ -49,7 +47,6 @@ walker:pub CreateSession {
         report {
             "id": new_session.id,
             "date": new_session.date,
-            "userId": new_session.userId,
             "title": new_session.title,
             "initialScore": new_session.initialScore,
             "finalScore": new_session.finalScore,
@@ -58,24 +55,19 @@ walker:pub CreateSession {
     }
 }
 
-walker:pub GetUserSessions {
-    has userId: str;
-
+walker:priv GetUserSessions {
     can run with Root entry {
         sessions = [];
 
         for s in [-->](?:Session) {
-            if s.userId == self.userId {
-                sessions.append({
-                    "id": s.id,
-                    "date": s.date,
-                    "userId": s.userId,
-                    "title": s.title,
-                    "initialScore": s.initialScore,
-                    "finalScore": s.finalScore,
-                    "notes": s.notes
-                });
-            }
+            sessions.append({
+                "id": s.id,
+                "date": s.date,
+                "title": s.title,
+                "initialScore": s.initialScore,
+                "finalScore": s.finalScore,
+                "notes": s.notes
+            });
         }
 
         report sessions;
@@ -83,17 +75,9 @@ walker:pub GetUserSessions {
 }
 
 
-walker:pub CalculateUserStats {
-    has userId: str;
-
+walker:priv CalculateUserStats {
     can run with Root entry {
-        sessions = [];
-
-        for s in [-->](?:Session) {
-            if s.userId == self.userId {
-                sessions.append(s);
-            }
-        }
+        sessions = [-->](?:Session);
 
         total_sessions = len(sessions);
 
@@ -121,13 +105,12 @@ walker:pub CalculateUserStats {
     }
 }
 
-walker:pub DeleteSession {
-    has sessionId: str,
-        userId: str;
+walker:priv DeleteSession {
+    has sessionId: str;
 
     can run with Root entry {
         for s in [-->](?:Session) {
-            if s.id == self.sessionId and s.userId == self.userId {
+            if s.id == self.sessionId {
                 del s;
                 break;
             }
@@ -136,13 +119,12 @@ walker:pub DeleteSession {
     }
 }
 
-walker:pub GetSessionGraph {
-    has sessionId: str,
-        userId: str;
+walker:priv GetSessionGraph {
+    has sessionId: str;
 
     can run with Root entry {
         for s in [-->](?:Session) {
-            if s.id == self.sessionId and s.userId == self.userId {
+            if s.id == self.sessionId {
                 visit s;
                 return;
             }

--- a/walkers/user_walkers.jac
+++ b/walkers/user_walkers.jac
@@ -3,27 +3,18 @@
 import time;
 import from graph.user_nodes { User }
 
-walker:pub CreateUser {
+walker:priv CreateUser {
     has name: str,
         email: str,
-        userType: str = "student",
-        isGuest: bool = False;
+        userType: str = "student";
 
     can run with Root entry {
-        for user in [-->](?:User) {
-            if user.email == self.email {
-                report {"error": "account_exists", "id": user.id};
-                return;
-            }
-        }
-
         new_user = (root ++> User(
             id=f"user_{int(time.time())}",
             name=self.name,
             email=self.email,
             userType=self.userType,
-            createdAt=str(int(time.time())),
-            isGuest=self.isGuest
+            createdAt=str(int(time.time()))
         ))[0];
 
         report new_user;
@@ -31,59 +22,32 @@ walker:pub CreateUser {
 }
 
 
-walker:pub GetUserProfile {
-    has userId: str;
-
+walker:priv GetUserProfile {
     can run with Root entry {
-        user_node = None;
-
-        for user in [-->](?:User) {
-            if user.id == self.userId or user.email == self.userId {
-                user_node = user;
-                break;
-            }
-        }
-
-        report user_node;
+        users = [-->](?:User);
+        report users[0] if users else None;
     }
 }
 
 
-walker:pub GetUserByEmail {
-    has email: str;
-
+walker:priv GetUserByEmail {
     can run with Root entry {
-        user_node = None;
-
-        for user in [-->](?:User) {
-            if user.email == self.email {
-                user_node = user;
-                break;
-            }
-        }
-
-        report user_node;
+        users = [-->](?:User);
+        report users[0] if users else None;
     }
 }
 
 
-walker:pub UpdateUserProfile {
-    has userId: str,
-        name: str = None,
+walker:priv UpdateUserProfile {
+    has name: str = None,
         userType: str = None,
         goals: list[str] = None,
         theme: str = None,
         accessibilityMode: bool = None;
 
     can run with Root entry {
-        user_node = None;
-
-        for user in [-->](?:User) {
-            if user.id == self.userId or user.email == self.userId {
-                user_node = user;
-                break;
-            }
-        }
+        users = [-->](?:User);
+        user_node = users[0] if users else None;
 
         if not user_node {
             report {"error": "User not found"};
@@ -101,16 +65,11 @@ walker:pub UpdateUserProfile {
 }
 
 
-walker:pub GetCurrentUser {
+walker:priv GetCurrentUser {
     can run with Root entry {
         try {
-            user = None;
-            for u in [-->](?:User) {
-                if not u.isGuest {
-                    user = u;
-                    break;
-                }
-            }
+            users = [-->](?:User);
+            user = users[0] if users else None;
 
             if not user {
                 report {"authenticated": False, "isGuest": True};


### PR DESCRIPTION
## Summary
User, Session, and Profile walkers currently take an explicit `userId`/`email` parameter and filter `[-->]` traversal results by it. Since jac-cloud already isolates each user's graph behind their own `root` node, this manual filtering is redundant and a source of bugs if the param is ever omitted or wrong.

- Drop `userId`/`email` params from `CreateUser`, `GetUserProfile`, `GetUserByEmail`, `UpdateUserProfile`, `GetUserSessions`, `CalculateUserStats`, `DeleteSession`, `GetSessionGraph`
- Mark these walkers `:priv` since they're only valid against the caller's own root
- Remove unused `isGuest` field + duplicate-email check on `User`
- Remove unused `userId` field on `Session`
- Minor JSX formatting fix in `main.jac`