### PR TITLE
Deduplicate graph lookup, evidence weighting, and LLM JSON parsing

### DIFF
--- a/graph/argument_graph_nodes.jac
+++ b/graph/argument_graph_nodes.jac
@@ -7,3 +7,13 @@ node ArgumentGraph {
         createdAt: str,
         updatedAt: str;
 }
+
+"Find a root-owned ArgumentGraph by id, or None if not found."
+def find_argument_graph(from_node: Root, graph_id: str) -> ArgumentGraph | None {
+    for graph in [from_node -->](?:ArgumentGraph) {
+        if graph.id == graph_id {
+            return graph;
+        }
+    }
+    return None;
+}

--- a/screens/ReviewScreen.cl.jac
+++ b/screens/ReviewScreen.cl.jac
@@ -174,23 +174,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         try {
             mutResult = await root spawn GenerateCounter(graphId=_gcGraphId, targetNodeId=_gcNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _gcNewScore = currentScore["overall"] if "overall" in currentScore else _gcPrevScore;
-                applyScoreDelta(_gcPrevScore, _gcNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-            _gcNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-            _gcFound = None;
-            _gci = 0;
-            while _gci < len(_gcNodes) {
-                if _gcNodes[_gci]["id"] == _gcNodeId { _gcFound = _gcNodes[_gci]; break; }
-                _gci = _gci + 1;
-            }
-            selectedNode = _gcFound;
+            applyMutationResult(mutData, _gcPrevScore, _gcNodeId);
         } except Exception { }
         isSaving = False;
         pushUpdate();
@@ -232,23 +216,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                 selectedTitle=pickedTitle, selectedUrl=pickedUrl
             );
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _pirNewScore = currentScore["overall"] if "overall" in currentScore else _pirPrevScore;
-                applyScoreDelta(_pirPrevScore, _pirNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-            _pirNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-            _pirFound = None;
-            _piri = 0;
-            while _piri < len(_pirNodes) {
-                if _pirNodes[_piri]["id"] == _pirNodeId { _pirFound = _pirNodes[_piri]; break; }
-                _piri = _piri + 1;
-            }
-            selectedNode = _pirFound;
+            applyMutationResult(mutData, _pirPrevScore, _pirNodeId);
         } except Exception { }
         investigateResults = [];
         isSaving = False;
@@ -277,23 +245,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         try {
             mutResult = await root spawn InvestigateNode(graphId=_afGraphId, nodeId=_afNodeId, addAsEvidence=True);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _afNewScore = currentScore["overall"] if "overall" in currentScore else _afPrevScore;
-                applyScoreDelta(_afPrevScore, _afNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-            _afNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-            _afFound = None;
-            _afi = 0;
-            while _afi < len(_afNodes) {
-                if _afNodes[_afi]["id"] == _afNodeId { _afFound = _afNodes[_afi]; break; }
-                _afi = _afi + 1;
-            }
-            selectedNode = _afFound;
+            applyMutationResult(mutData, _afPrevScore, _afNodeId);
         } except Exception { }
         isSaving = False;
         addedAsEvidenceMap[_afNodeId] = True;
@@ -315,23 +267,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                 evidenceContent=_aeMoreInfo, sourceUrl=_aeSourceUrl
             );
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _aeNewScore = currentScore["overall"] if "overall" in currentScore else _aePrevScore;
-                applyScoreDelta(_aePrevScore, _aeNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-            _aeNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-            _aeFound = None;
-            _aei = 0;
-            while _aei < len(_aeNodes) {
-                if _aeNodes[_aei]["id"] == _aeNodeId { _aeFound = _aeNodes[_aei]; break; }
-                _aei = _aei + 1;
-            }
-            selectedNode = _aeFound;
+            applyMutationResult(mutData, _aePrevScore, _aeNodeId);
         } except Exception { }
         isSaving = False;
         addedAsEvidenceMap[_aeNodeId] = True;
@@ -363,6 +299,30 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                 showScoreDelta = False;
                 scoreDelta = 0;
             }, 2200);
+        }
+    }
+
+    # Apply a mutation walker's report to graph/score/issues/nextActions state,
+    # and (if reselectNodeId is given) refresh selectedNode from the new graph.
+    def applyMutationResult(mutData: dict, prevScore: int, reselectNodeId: str | None) -> None {
+        if "graph" in mutData { currentGraph = mutData["graph"]; }
+        if "score" in mutData {
+            currentScore = mutData["score"];
+            _newScore = currentScore["overall"] if "overall" in currentScore else prevScore;
+            applyScoreDelta(prevScore, _newScore);
+        }
+        if "issues" in mutData { currentIssues = mutData["issues"]; }
+        if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
+        if reselectNodeId {
+            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
+            _nodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
+            _found = None;
+            _i = 0;
+            while _i < len(_nodes) {
+                if _nodes[_i]["id"] == reselectNodeId { _found = _nodes[_i]; break; }
+                _i = _i + 1;
+            }
+            selectedNode = _found;
         }
     }
 
@@ -409,23 +369,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
             }
             if mutResult {
                 mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-                if "graph" in mutData { currentGraph = mutData["graph"]; }
-                if "score" in mutData {
-                    currentScore = mutData["score"];
-                    _seNewScore = currentScore["overall"] if "overall" in currentScore else _sePrevScore;
-                    applyScoreDelta(_sePrevScore, _seNewScore);
-                }
-                if "issues" in mutData { currentIssues = mutData["issues"]; }
-                if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-                _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-                _seNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-                _seFound = None;
-                _sefi = 0;
-                while _sefi < len(_seNodes) {
-                    if _seNodes[_sefi]["id"] == _seNodeId { _seFound = _seNodes[_sefi]; break; }
-                    _sefi = _sefi + 1;
-                }
-                selectedNode = _seFound;
+                applyMutationResult(mutData, _sePrevScore, _seNodeId);
             }
         } except Exception { }
 
@@ -470,14 +414,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         try {
             mutResult = await root spawn DeleteNode(graphId=_delGraphId, nodeId=_delNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _delNewScore = currentScore["overall"] if "overall" in currentScore else _delPrevScore;
-                applyScoreDelta(_delPrevScore, _delNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
+            applyMutationResult(mutData, _delPrevScore, None);
         } except Exception { }
 
         selectedNode = None;
@@ -525,14 +462,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
                 graphId=_acGraphId, targetNodeId=ca_target, counterargContent=ca_text
             );
             addData = addResult["reports"][0] if addResult["reports"] else {};
-            if "graph" in addData { currentGraph = addData["graph"]; }
-            if "score" in addData {
-                currentScore = addData["score"];
-                _acNewScore = currentScore["overall"] if "overall" in currentScore else _acPrevScore;
-                applyScoreDelta(_acPrevScore, _acNewScore);
-            }
-            if "issues" in addData { currentIssues = addData["issues"]; }
-            if "nextActions" in addData { currentNextActions = addData["nextActions"]; }
+            applyMutationResult(addData, _acPrevScore, None);
         } except Exception { }
 
         isSaving = False;
@@ -548,23 +478,7 @@ def:pub ReviewScreen(props: any) -> JsxElement {
         try {
             mutResult = await root spawn ExpandBranch(graphId=_ebGraphId, nodeId=_ebNodeId);
             mutData = mutResult["reports"][0] if mutResult["reports"] else {};
-            if "graph" in mutData { currentGraph = mutData["graph"]; }
-            if "score" in mutData {
-                currentScore = mutData["score"];
-                _ebNewScore = currentScore["overall"] if "overall" in currentScore else _ebPrevScore;
-                applyScoreDelta(_ebPrevScore, _ebNewScore);
-            }
-            if "issues" in mutData { currentIssues = mutData["issues"]; }
-            if "nextActions" in mutData { currentNextActions = mutData["nextActions"]; }
-            _freshGraph = mutData["graph"] if "graph" in mutData else currentGraph;
-            _ebNodes = _freshGraph["nodes"] if _freshGraph and "nodes" in _freshGraph else [];
-            _ebFound = None;
-            _ebi = 0;
-            while _ebi < len(_ebNodes) {
-                if _ebNodes[_ebi]["id"] == _ebNodeId { _ebFound = _ebNodes[_ebi]; break; }
-                _ebi = _ebi + 1;
-            }
-            selectedNode = _ebFound;
+            applyMutationResult(mutData, _ebPrevScore, _ebNodeId);
         } except Exception { }
         isSaving = False;
         pushUpdate();

--- a/src/graph_generator.jac
+++ b/src/graph_generator.jac
@@ -8,6 +8,16 @@ import time;
 
 # Model is configured in jac.toml under [plugins.byllm.model]
 
+# Single source of truth for evidence-category base quality weights.
+# Previously redefined inconsistently across 6 locations.
+def evidence_category_weight(category: str, fallback: float = 0.6) -> float {
+    weights: dict[str, float] = {
+        "empirical_data": 0.9, "expert_testimony": 0.8,
+        "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
+    };
+    return weights.get(category, fallback);
+}
+
 # ============================================================
 # 1. DATA TYPES
 # ============================================================
@@ -298,11 +308,7 @@ def:pub categorize_evidence_fast(text: str) -> dict {
     if confidence > 1.0 { confidence = 1.0; }
 
     # Compute node score from category weights + confidence
-    cat_weights: dict[str, float] = {
-        "empirical_data": 0.9, "expert_testimony": 0.8,
-        "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
-    };
-    base_quality = cat_weights.get(category, 0.6);
+    base_quality = evidence_category_weight(category);
     # Factor in confidence — low confidence drags down the score
     quality = base_quality * 0.5 + confidence * 0.5;
     assumption_penalty = len(assumptions) * 0.1;
@@ -330,24 +336,34 @@ def:pub extract_llm_text(raw: object) -> str {
     return str(raw);
 }
 
-"Parse JSON string from LLM, handling markdown fences."
-def safe_parse_json(raw: object) -> list {
-    cleaned = extract_llm_text(raw).strip();
+"Strip a leading/trailing markdown code fence (```json ... ```) from LLM output."
+def strip_json_fences(text: str) -> str {
+    cleaned = text.strip();
     if cleaned.startswith("```") {
         lines = cleaned.split("\n");
-        if lines[0].startswith("```") {
-            lines = lines[1:];
-        }
+        lines = lines[1:];
         if lines and lines[-1].strip().startswith("```") {
             lines = lines[:-1];
         }
         cleaned = "\n".join(lines).strip();
     }
+    return cleaned;
+}
+
+"Parse JSON string from LLM, handling markdown fences."
+def safe_parse_json(raw: object) -> list {
+    cleaned = strip_json_fences(extract_llm_text(raw).strip());
     try {
         return json.loads(cleaned);
     } except Exception {
         return [];
     }
+}
+
+"Parse a JSON object from raw LLM output, handling markdown fences."
+def parse_llm_json_object(raw: object) -> dict {
+    cleaned = strip_json_fences(extract_llm_text(raw).strip());
+    return json.loads(cleaned);
 }
 
 "Count incoming edges by label for a node."
@@ -601,17 +617,11 @@ def calculate_score(
         return ReasoningScore();
     }
 
-    # Evidence quality base weights by category
-    category_weights: dict[str, float] = {
-        "empirical_data": 0.9, "expert_testimony": 0.8,
-        "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
-    };
-
     # Score each evidence node by category and assumptions
     evidence_nodes = [n for n in nodes if n.label == "evidence"];
     evidence_scores: dict[str, float] = {};
     for ev in evidence_nodes {
-        base = category_weights.get(ev.evidence_category, 0.6);
+        base = evidence_category_weight(ev.evidence_category);
         # Each unaddressed assumption reduces quality by 15%
         assumption_count = len(ev.assumptions) if ev.assumptions else 0;
         penalty = assumption_count * 0.15;

--- a/walkers/graph_generate_walkers.jac
+++ b/walkers/graph_generate_walkers.jac
@@ -1,7 +1,7 @@
 """Walkers for generating and scoring argument graphs."""
 
-import from graph.argument_graph_nodes { ArgumentGraph }
-import from src.graph_generator { Document, generate_argument_graph }
+import from graph.argument_graph_nodes { ArgumentGraph, find_argument_graph }
+import from src.graph_generator { Document, generate_argument_graph, evidence_category_weight }
 
 walker:pub GenerateArgumentGraph {
     has notes: str;
@@ -248,13 +248,7 @@ walker:pub GetGraphWithScoring {
     has graphId: str;
 
     can run with Root entry {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -387,15 +381,8 @@ walker:pub GetGraphWithScoring {
             return 0.0;
         }
 
-        cat_weights: dict[str, float] = {
-            "empirical_data": 0.92,
-            "expert_testimony": 0.82,
-            "logical_reasoning": 0.65,
-            "analogy": 0.52,
-            "anecdotal": 0.38
-        };
         ev_cat = str(node_data.get("evidence_category", "logical_reasoning")).lower().strip();
-        base = cat_weights.get(ev_cat, 0.65);
+        base = evidence_category_weight(ev_cat);
 
         conf = self.to_float(node_data.get("confidence", 0.5), 0.5);
         conf = self.clamp01(conf);

--- a/walkers/graph_revise_walkers.jac
+++ b/walkers/graph_revise_walkers.jac
@@ -1,7 +1,7 @@
 """Walkers for revising argument graph nodes."""
 
-import from graph.argument_graph_nodes { ArgumentGraph }
-import from src.graph_generator { evaluate_single_evidence, generate_counterargument, clarify_node_content, extract_llm_text, categorize_evidence_fast, expand_branch, extract_search_keywords, pick_best_wiki_result }
+import from graph.argument_graph_nodes { ArgumentGraph, find_argument_graph }
+import from src.graph_generator { evaluate_single_evidence, generate_counterargument, clarify_node_content, extract_llm_text, categorize_evidence_fast, expand_branch, extract_search_keywords, pick_best_wiki_result, evidence_category_weight, parse_llm_json_object }
 import from walkers.graph_generate_walkers { GetGraphWithScoring }
 import time;
 import json;
@@ -17,13 +17,7 @@ walker:pub AddEvidenceToNode {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -142,16 +136,7 @@ walker:pub AddEvidenceToNode {
                     thesis_text=_ev_thesis,
                     context_description=_ev_context
                 );
-                _eval_str = extract_llm_text(raw_eval).strip();
-                if _eval_str.startswith("```") {
-                    _ef_lines = _eval_str.split("\n");
-                    _ef_lines = _ef_lines[1:];
-                    if _ef_lines and _ef_lines[-1].strip().startswith("```") {
-                        _ef_lines = _ef_lines[:-1];
-                    }
-                    _eval_str = "\n".join(_ef_lines).strip();
-                }
-                _eval_parsed = json.loads(_eval_str);
+                _eval_parsed = parse_llm_json_object(raw_eval);
 
                 _eval_cat = _eval_parsed.get("evidence_category", ev_category);
                 _eval_assumptions: list = _eval_parsed.get("assumptions", []);
@@ -169,11 +154,7 @@ walker:pub AddEvidenceToNode {
                     else { _capped.append(_ea_s); }
                 }
 
-                _cat_weights: dict[str, float] = {
-                    "empirical_data": 0.9, "expert_testimony": 0.8,
-                    "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
-                };
-                _base_q = _cat_weights.get(_eval_cat, 0.6);
+                _base_q = evidence_category_weight(_eval_cat);
                 _quality = _base_q - len(_capped) * 0.15;
                 if _quality < 0.1 { _quality = 0.1; }
                 _eval_score = int(_quality * 100);
@@ -222,13 +203,7 @@ walker:pub AddAssumptionToEvidence {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -299,13 +274,7 @@ walker:pub UpdateNodeContent {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -379,13 +348,7 @@ walker:pub DeleteNode {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -425,13 +388,7 @@ walker:pub AddCounterargumentNode {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -525,13 +482,7 @@ walker:pub AddAddressEdge {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -620,16 +571,7 @@ walker:pub AddAddressEdge {
                 thesis_text=_addr_thesis,
                 context_description=_addr_context
             );
-            _eval_str = extract_llm_text(raw_eval).strip();
-            if _eval_str.startswith("```") {
-                _ef_lines = _eval_str.split("\n");
-                _ef_lines = _ef_lines[1:];
-                if _ef_lines and _ef_lines[-1].strip().startswith("```") {
-                    _ef_lines = _ef_lines[:-1];
-                }
-                _eval_str = "\n".join(_ef_lines).strip();
-            }
-            _eval_parsed = json.loads(_eval_str);
+            _eval_parsed = parse_llm_json_object(raw_eval);
 
             _eval_cat = _eval_parsed.get("evidence_category", "logical_reasoning");
             _eval_assumptions: list = _eval_parsed.get("assumptions", []);
@@ -690,13 +632,7 @@ walker:pub EvaluateNewNode {
     can run with Root entry {
         try {
         print(f"=== EvaluateNewNode: graphId={self.graphId}, nodeId={self.nodeId} ===");
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -738,17 +674,7 @@ walker:pub EvaluateNewNode {
             # Parse LLM response
             parsed = {};
             try {
-                raw_str = extract_llm_text(raw_result).strip();
-                # Handle markdown fences
-                if raw_str.startswith("```") {
-                    fence_lines = raw_str.split("\n");
-                    fence_lines = fence_lines[1:];
-                    if fence_lines and fence_lines[-1].strip().startswith("```") {
-                        fence_lines = fence_lines[:-1];
-                    }
-                    raw_str = "\n".join(fence_lines).strip();
-                }
-                parsed = json.loads(raw_str);
+                parsed = parse_llm_json_object(raw_result);
             } except Exception {
                 parsed = {};
             }
@@ -782,12 +708,7 @@ walker:pub EvaluateNewNode {
                 }
             }
 
-            # Category quality weights
-            cat_weights: dict[str, float] = {
-                "empirical_data": 0.9, "expert_testimony": 0.8,
-                "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
-            };
-            base_quality = cat_weights.get(ev_category, 0.6);
+            base_quality = evidence_category_weight(ev_category);
             quality = base_quality - len(capped_assumptions) * 0.15;
             if quality < 0.1 { quality = 0.1; }
             node_score = int(quality * 100);
@@ -851,13 +772,7 @@ walker:pub GenerateCounter {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -886,16 +801,7 @@ walker:pub GenerateCounter {
             claim_text=target_content,
             thesis_text=thesis_text
         );
-        raw_str = extract_llm_text(raw_result).strip();
-        if raw_str.startswith("```") {
-            fence_lines = raw_str.split("\n");
-            fence_lines = fence_lines[1:];
-            if fence_lines and fence_lines[-1].strip().startswith("```") {
-                fence_lines = fence_lines[:-1];
-            }
-            raw_str = "\n".join(fence_lines).strip();
-        }
-        parsed = json.loads(raw_str);
+        parsed = parse_llm_json_object(raw_result);
         ca_text = parsed.get("counterargument", "");
 
         if not ca_text {
@@ -987,13 +893,7 @@ walker:pub ClarifyNode {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -1026,16 +926,7 @@ walker:pub ClarifyNode {
             node_type=node_type,
             thesis_text=thesis_text
         );
-        raw_str = extract_llm_text(raw_result).strip();
-        if raw_str.startswith("```") {
-            fence_lines = raw_str.split("\n");
-            fence_lines = fence_lines[1:];
-            if fence_lines and fence_lines[-1].strip().startswith("```") {
-                fence_lines = fence_lines[:-1];
-            }
-            raw_str = "\n".join(fence_lines).strip();
-        }
-        parsed = json.loads(raw_str);
+        parsed = parse_llm_json_object(raw_result);
         more_info = parsed.get("moreInfo", "");
         source_hint = parsed.get("sourceHint", "");
 
@@ -1115,13 +1006,7 @@ walker:pub InvestigateNode {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -1585,13 +1470,7 @@ walker:pub ExpandBranch {
 
     can run with Root entry {
         try {
-        graph_node = None;
-        for graph in [-->](?:ArgumentGraph) {
-            if graph.id == self.graphId {
-                graph_node = graph;
-                break;
-            }
-        }
+        graph_node = find_argument_graph(root, self.graphId);
 
         if not graph_node {
             report {"error": "Graph not found"};
@@ -1624,16 +1503,7 @@ walker:pub ExpandBranch {
             node_type=node_type,
             thesis_text=thesis_text
         );
-        raw_str = extract_llm_text(raw_result).strip();
-        if raw_str.startswith("```") {
-            fence_lines = raw_str.split("\n");
-            fence_lines = fence_lines[1:];
-            if fence_lines and fence_lines[-1].strip().startswith("```") {
-                fence_lines = fence_lines[:-1];
-            }
-            raw_str = "\n".join(fence_lines).strip();
-        }
-        parsed = json.loads(raw_str);
+        parsed = parse_llm_json_object(raw_result);
         branches = parsed.get("branches", []);
 
         if not branches {
@@ -1702,11 +1572,7 @@ walker:pub ExpandBranch {
                 cat_res = categorize_evidence_fast(b_content);
                 b_category = cat_res.get("evidence_category", "logical_reasoning");
                 # Use LLM confidence but cap by category quality
-                cat_weights: dict[str, float] = {
-                    "empirical_data": 0.9, "expert_testimony": 0.8,
-                    "logical_reasoning": 0.6, "analogy": 0.5, "anecdotal": 0.3
-                };
-                cat_quality = cat_weights.get(b_category, 0.6);
+                cat_quality = evidence_category_weight(b_category);
                 combined = cat_quality * 0.4 + b_confidence * 0.6;
                 b_node_score = int(combined * 100);
             }


### PR DESCRIPTION
## Summary
- Extract the repeated root-owned `ArgumentGraph` lookup loop (copy-pasted across 11+ walker methods) into a single `find_argument_graph` helper.
- Extract the evidence-category weight table, previously redefined inconsistently across 6 locations, into `evidence_category_weight`.
- Extract the markdown-fence-stripping + JSON parsing logic, repeated across several walkers, into `strip_json_fences` / `parse_llm_json_object`.
- Factor `ReviewScreen`'s repeated post-mutation graph/score/issues/nextActions refresh (and node reselection) into a single `applyMutationResult` helper.

## Why
These pieces of logic had drifted slightly out of sync across copies (e.g. different weight values in `GetGraphWithScoring` vs `graph_generator.jac`), making future tuning error-prone. Consolidating gives one source of truth per concern.